### PR TITLE
Styleguidist IE11 issue resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,10 +381,6 @@ Stylelint setup for the current project.
 
 ## Known issues
 
-### Styleguidist
-
-The styleguidist part of this application currently is not running on IE11 unfortunately (@see https://github.com/vue-styleguidist/vue-styleguidist/issues/83).
-
 ### Webpack
 
 #### Webpack does not perform code splitting


### PR DESCRIPTION
Fixed it, on the version 1.7.7
https://github.com/vue-styleguidist/vue-styleguidist/issues/83

## Pull request
Updated the readme with the IE11 issue of vue-styleguidist
