### PR TITLE
Updates eslint-config-valantic which now also includes vue plugin rules.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,6 @@
 // https://eslint.org/docs/user-guide/configuring
 const webpackConfig = require('./webpack.config');
-
-// TODO: review
+const vueRules = require('eslint-config-valantic/plugins/vue');
 
 module.exports = {
   root: true,
@@ -33,6 +32,7 @@ module.exports = {
   },
   // add your custom rules here
   rules: {
+    ...vueRules,
     'require-jsdoc': [2, {
       require: {
         FunctionDeclaration: true,
@@ -42,77 +42,11 @@ module.exports = {
         FunctionExpression: false
       }
     }],
-    'id-length': [1, {
-      min: 3,
-      properties: 'always',
-      exceptions: [
-        '$',
-        'a',
-        'b',
-        'e',
-        'i',
-        'in', // ember-cp-validations
-        'j',
-        'x',
-        'y',
-        '_', // _Lowdash
-        'fs', // ember
-        'gt', // ember-cp-validations
-        'id',
-        'DS', // ember-data
-        'el', // Vue
-        'on', // Vue
-        'vm', // Vue
-        'xs', // Bootstrap
-        'sm', // Bootstrap
-        'md', // Bootstrap
-        'lg', // Bootstrap
-        'xl', // Bootstrap
-      ]
-    }],
 
     // don't require .vue extension when importing
     'import/extensions': [0, 'always', {
       js: 'never',
       vue: 'never'
-    }],
-    'vue/max-attributes-per-line': [2, {
-      'singleline': 3,
-      'multiline': {
-        'max': 1,
-        'allowFirstLine': true
-      }
-    }],
-    'vue/name-property-casing': [2, 'kebab-case'],
-    'vue/html-closing-bracket-newline': [0],
-    // 'vue/multiline-html-element-content-newline': [1, { // TODO: currently does not allow additional properties (bug, https://github.com/vuejs/eslint-plugin-vue/issues/792)
-    //   ignoreWhenEmpty: true,
-    //   ignores: ['pre', 'textarea'],
-    //   allowEmptyLines: true
-    // }],
-    'vue/singleline-html-element-content-newline': [1, {
-      'ignoreWhenNoAttributes': true,
-      'ignoreWhenEmpty': true,
-      'ignores': [
-        'code',
-        'pre',
-        'span',
-        'textarea',
-      ]
-    }],
-    'indent': 0, // Indent is not working with html script tag. Use 'vue/script-indent' instead
-    'vue/script-indent': ['error', 2, {
-      'baseIndent': 1,
-      'switchCase': 1
-    }],
-    'vue/html-self-closing': [2, {
-      'html': {
-        'void': 'never',
-        'normal': 'never', // Don't close default elements
-        'component': 'always'
-      },
-      'svg': 'always',
-      'math': 'always'
     }]
   },
   globals: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4165,8 +4165,7 @@
           "version": "2.7.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "acorn-globals": {
           "version": "1.0.9",
@@ -7118,9 +7117,9 @@
       }
     },
     "eslint-config-valantic": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-valantic/-/eslint-config-valantic-6.0.0.tgz",
-      "integrity": "sha512-SO+vqWIhSIrzj25NXeJQnGg7aJ485AC/DtUqwNsX1vTRXLdafrseEa/YzR/8/uqwpyS//+TZfJEVCoL8GxZzAQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-valantic/-/eslint-config-valantic-6.1.0.tgz",
+      "integrity": "sha512-tmh1JYw4aCwfmkIbBHeen19tlnG6t0RQ55T9tQDfPychFPI67FEcem7nvVqdwSYaR3Z2RBMl81UTQ00nLtWIsg==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -8570,8 +8569,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8592,14 +8590,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8614,20 +8610,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8744,8 +8737,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8757,7 +8749,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8772,7 +8763,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8780,14 +8770,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8806,7 +8794,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8887,8 +8874,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8900,7 +8886,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8986,8 +8971,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9023,7 +9007,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9043,7 +9026,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9087,14 +9069,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "css-loader": "~1.0.1",
     "eslint": "~5.12.1",
     "eslint-config-airbnb-base": "~13.1.0",
-    "eslint-config-valantic": "~6.0.0",
+    "eslint-config-valantic": "~6.1.0",
     "eslint-import-resolver-webpack": "~0.11.0",
     "eslint-loader": "~2.1.1",
     "eslint-plugin-import": "~2.16.0",


### PR DESCRIPTION
## Pull request
This PR adds a new `eslint-config-valantic` version which also includes vue plugin settings.
 
### Ticket
No ticket
 
### Browser testing
- localhost
 
### Checklist
- [x] I merged the current development branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [x] Did run automated tests and linters
- [ ] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did run automated tests and linters
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
