### PR TITLE
Feature/update vue i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,18 @@ All text which is defined in frontend MUST be placed trough translations. There 
 
 We use the [vue-i18n](https://github.com/kazupon/vue-i18n) plugin to handle translations. This tool also allows us to handle localizations (e.g. number or date formats). The documentation can be found [here](https://kazupon.github.io/vue-i18n/guide/started.html).
 
+Use as directive:
+```html
+<span v-t="'c-example.title'"></span>
+```
+
+Use as directive inside a transition:
+```html
+<transition name="fade">
+  <span v-if="toggle" v-t.preserve="'c-example.title'"></span>
+</transition>
+```
+
 ### Placeholders
 
 vue-i18n allows the usage of [placeholders](https://kazupon.github.io/vue-i18n/guide/formatting.html#named-formatting). This means you should add dynamic parts with a placeholder to the translation and not concatenate them in the component template or JavaScript.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23863,9 +23863,9 @@
       "dev": true
     },
     "vue-i18n": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.3.2.tgz",
-      "integrity": "sha512-MQ06tG1Tl/VL6NDh6XXfGr1uI6KVinb4fuu4alprwmbn5BG0J/a1RIVSSOsDmGkYKKaHlLzvRydiiulnBy2iXQ=="
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.8.1.tgz",
+      "integrity": "sha512-phAJs7iF06QxMY1Thd5c6WJnRSSp4fOG/352eiuRTWMlqBEOFApVa0q1TD//NEguKBO0qCz0gEckFpHWJzJA2Q=="
     },
     "vue-jest": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "swiper": "~4.4.6",
     "vue": "~2.5.22",
     "vue-bem-cn": "~1.1.1",
-    "vue-i18n": "~8.3.2",
+    "vue-i18n": "~8.8.1",
     "vue-js-modal": "~1.3.28",
     "vue-router": "~3.0.2",
     "vue-tabs-component": "~1.5.0",


### PR DESCRIPTION
## Pull request
Updates the version of `vue-i18n` to the latest version.
This is needed to use the v-t directive with "preserve" modifier inside a transition.
https://kazupon.github.io/vue-i18n/guide/directive.html#use-with-transitions
 
### Ticket
https://github.com/valantic/vue-template/issues/71
 
### Browser testing
- -
 
### Checklist
- [ ] I merged the current development branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [x] Did run automated tests and linters
- [ ] Did assign ticket
- [ ] Double checked target branch
 
## Review/Test checklist
- [ ] Did run automated tests and linters
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
