### PR TITLE
Extends e-select with the possibility to customize the value and labe…

### DIFF
--- a/src/components/e-select.md
+++ b/src/components/e-select.md
@@ -1,9 +1,11 @@
-### Default
+### States
+
+#### State: default
 
 ```vue
 <template>
   <div>
-    <e-select v-model="demo" :options-list="optionsList" name="demo-select"/>
+    <e-select v-model="demo" :options="optionsList" name="demo-select"/>
     <div v-if="demo" class="spacing--top-15">
       <p>{{ demo }}</p>
     </div>
@@ -33,10 +35,10 @@
 </script>
 ```
 
-#### `:disabled`
+#### State: `:disabled`
 ```vue
 <template>
-  <e-select v-model="demo" disabled :options-list="optionsList" name="demo-select"/>
+  <e-select v-model="demo" disabled :options="optionsList" name="demo-select"/>
 </template>
 
 <script>
@@ -54,12 +56,12 @@
 </script>
 ```
 
-#### `:hover`
+#### State: `:hover`
 
 ```vue
 <template>
   <div>
-    <e-select hover v-model="demo" :options-list="optionsList" name="demo-select"/>
+    <e-select hover v-model="demo" :options="optionsList" name="demo-select"/>
     <div v-if="demo" class="spacing--top-15">
       <p>{{ demo }}</p>
     </div>
@@ -89,12 +91,12 @@
 </script>
 ```
 
-#### `:focus`
+#### State: `:focus`
 
 ```vue
 <template>
   <div>
-    <e-select focus v-model="demo" :options-list="optionsList" name="demo-select"/>
+    <e-select focus v-model="demo" :options="optionsList" name="demo-select"/>
     <div v-if="demo" class="spacing--top-15">
       <p>{{ demo }}</p>
     </div>
@@ -124,12 +126,12 @@
 </script>
 ```
 
-#### state: `error`
+#### State: `error`
 
 ```vue
 <template>
   <div>
-    <e-select state="error" v-model="demo" :options-list="optionsList" name="demo-select"/>
+    <e-select state="error" v-model="demo" :options="optionsList" name="demo-select"/>
     <div v-if="demo" class="spacing--top-15">
       <p>{{ demo }}</p>
     </div>
@@ -159,12 +161,87 @@
 </script>
 ```
 
-#### state: `success`
+#### State: `success`
 
 ```vue
 <template>
   <div>
-    <e-select state="success" v-model="demo" :options-list="optionsList" name="demo-select"/>
+    <e-select state="success" v-model="demo" :options="optionsList" name="demo-select"/>
+    <div v-if="demo" class="spacing--top-15">
+      <p>{{ demo }}</p>
+    </div>
+  </div>
+</template>
+
+<script>
+  export default {
+    data: () => ({
+      demo: 'option-3',
+      optionsList: [
+        {
+          value: 'option-1',
+          label: 'Dies ist eine etwas längere option',
+        },
+        {
+          value: 'option-2',
+          label: 'Option 2',
+        },
+        {
+          value: 'option-3',
+          label: 'Option 3',
+        },
+      ]
+    })
+  };
+</script>
+```
+
+### Customized value and label fields
+
+```vue
+<template>
+  <div>
+    <e-select
+      v-model="demo"
+      :options="optionsList"
+      value-field="code"
+      label-field="text"
+      name="demo-select"/>
+    <div v-if="demo" class="spacing--top-15">
+      <p>{{ demo }}</p>
+    </div>
+  </div>
+</template>
+
+<script>
+  export default {
+    data: () => ({
+      demo: 'option-3',
+      optionsList: [
+        {
+          code: 'option-1',
+          text: 'Dies ist eine etwas längere option',
+        },
+        {
+          code: 'option-2',
+          text: 'Option 2',
+        },
+        {
+          code: 'option-3',
+          text: 'Option 3',
+        },
+      ]
+    })
+  };
+</script>
+```
+
+### Progress
+
+```vue
+<template>
+  <div>
+    <e-select v-model="demo" :options="optionsList" name="demo-select" progress />
     <div v-if="demo" class="spacing--top-15">
       <p>{{ demo }}</p>
     </div>

--- a/src/components/e-select.vue
+++ b/src/components/e-select.vue
@@ -1,33 +1,37 @@
 <template>
-  <span :class="b(stateModifiers)">
+  <div :class="b(stateModifiers)">
     <select :value="value"
             :class="b('select')"
             :disabled="disabled || progress"
             v-bind="$attrs"
             @change="onChange"
     >
-      <option :disabled="!hasSelectablePlaceholder" value="">
+      <option v-if="placeholder"
+              :disabled="!hasSelectablePlaceholder"
+              value=""
+      >
         {{ placeholder }}
       </option>
-      <option v-for="item in optionsList"
-              :key="`${name}-${item.value}`"
-              :value="item.value"
-              :selected="item.value === value">
-        {{ item.label }}
+      <option v-for="option in options"
+              :key="`${option[valueField]}`"
+              :value="option[valueField]"
+              :selected="option[valueField] === value">
+        {{ option[labelField] }}
       </option>
     </select>
     <span v-if="!hasDefaultState" :class="b('icon-splitter')"></span>
     <div v-if="progress" :class="b('progress-container')">
       <e-progress />
     </div>
-  </span>
+  </div>
 </template>
 
 <script>
+  import { i18n } from '@/setup/i18n';
   import formStates from '../mixins/form-states';
 
   /**
-   * Renders a styled select element. Options can be passed with the `optionsList` property.
+   * Renders a styled select element. Options can be passed with the `options` property.
    */
   export default {
     name: 'e-select',
@@ -55,23 +59,25 @@
       },
 
       /**
-       * OptionsList defines the options which are rendered in the select.
+       * 'options' defines the options which are rendered in the select.
        *
-       * e.g. `[{ value: <option-1>, label: <Option 1> },{ value: <option-2>, label: <Option 2>},...]`
+       * e.g. `[{ <valueField>: 'id1', <labelField>: 'Label 1' },{ <valueField>: 'id2', <labelField>: 'Label 2' },...]`
        */
-      optionsList: {
+      options: {
         required: true,
         type: Array,
       },
 
       /**
        * The text to display if no option is selected by default.
+       * The placeholder can also be disabled by passing 'false' to this prop.
        */
       placeholder: {
-        default() {
-          return this.$t('e-select.chooseOption');
+        type: [String, Boolean],
+        default: i18n.t('e-select.chooseOption'),
+        validator(value) {
+          return typeof value === 'string' || value === false;
         },
-        type: String,
       },
 
       /**
@@ -88,6 +94,22 @@
       progress: {
         type: Boolean,
         default: false,
+      },
+
+      /**
+       * Allows to change the default field, from which the value is taken for each option.
+       */
+      valueField: {
+        type: String,
+        default: 'value',
+      },
+
+      /**
+       * Allows to change the default field, from which the label text is taken for each option.
+       */
+      labelField: {
+        type: String,
+        default: 'label',
       },
     },
     // data() {
@@ -122,7 +144,7 @@
          * @type {String}
          */
         this.$emit('input', event.currentTarget.value);
-      }
+      },
     },
     // render() {},
   };

--- a/src/styleguide/routes/forms.vue
+++ b/src/styleguide/routes/forms.vue
@@ -51,7 +51,7 @@
       <!-- e-select -->
       <div :class="b('part')">
         <e-label name="Language" position="top">
-          <e-select v-model="demo.language" :options-list="mock.selects" name="language" />
+          <e-select v-model="demo.language" :options="mock.selects" name="language" />
         </e-label>
       </div>
 


### PR DESCRIPTION
## Pull request
This PR extends the e-select component with the possibility to change the default label and value field names to something else. This way, we can prevent mapping arrays before giving them to the select component.
 
### Ticket
No ticket
 
### Browser testing
- http://localhost:6060/styleguide#!/Elements/e-select
 
### Checklist
- [x] I merged the current development branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [x] Did run automated tests and linters
- [ ] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did run automated tests and linters
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
