### PR TITLE
#132: adds html validation CSS

### DIFF
--- a/src/styleguide/components/s-demo-settings.vue
+++ b/src/styleguide/components/s-demo-settings.vue
@@ -1,6 +1,9 @@
 <template>
   <ul :class="b()">
     <li :class="b('item')">
+      <s-toggle v-model="htmlValidation">
+        HTML validation
+      </s-toggle>
       <s-toggle checked>
         Logged in
       </s-toggle>
@@ -10,6 +13,8 @@
 
 <script>
   import sToggle from './s-toggle';
+
+  const showHtmlValidationClass = 'html-validation';
 
   export default {
     name: 's-demo-settings',
@@ -21,12 +26,28 @@
     // mixins: [],
 
     // props: {},
-    // data() {
-    //   return {};
-    // },
+    data() {
+      return {
+        /**
+         * @type {Boolean} Determines if the HTML validation styles should be applied.
+         */
+        htmlValidation: true,
+      };
+    },
 
     // computed: {},
-    // watch: {},
+    watch: {
+      htmlValidation: {
+        immediate: true,
+        handler(show) {
+          if (show) {
+            document.body.classList.add(showHtmlValidationClass);
+          } else {
+            document.body.classList.remove(showHtmlValidationClass);
+          }
+        }
+      },
+    },
 
     // beforeCreate() {},
     // created() {},
@@ -49,3 +70,5 @@
     @extend %list-reset;
   }
 </style>
+
+<style src="@/styleguide/html-validation.scss"></style>

--- a/src/styleguide/html-validation.scss
+++ b/src/styleguide/html-validation.scss
@@ -1,0 +1,112 @@
+// stylelint-disable
+
+.html-validation {
+  @mixin html-validator-warning($message: "") {
+    $red: #ff0000;
+    $black: #000000;
+
+    outline: 5px solid $red;
+
+    &::before {
+      content: $message;
+      position: absolute;
+      z-index: 1000;
+      border: 1px solid $red;
+      padding: 2px $spacing--5;
+      background: lighten($red, 40%);
+      color: $black;
+      max-width: 200px;
+      font-size: 0.8rem;
+    }
+  }
+
+  a {
+    button {
+      @include html-validator-warning('The element <button> must not appear as a descendant of the <a> element.');
+    }
+  }
+
+  button {
+    &:not([aria-label]):not([aria-labelledby]):empty {
+      @include html-validator-warning('Ensure that <button> has meaningful content or is labelled appropriately.');
+    }
+
+    div {
+      @include html-validator-warning('Element <div> not allowed as child of element <button>.');
+    }
+  }
+
+  img {
+    &[sizes^=','] {
+      @include html-validator-warning('Bad value for attribute "sizes" on element <img>: Starts with empty source size.');
+    }
+  }
+
+  label {
+    button,
+    input,
+    meter,
+    output,
+    progress,
+    select,
+    textarea {
+      &[aria-label],
+      &:nth-of-type(2),
+      & ~ button,
+      & ~ input,
+      & ~ meter,
+      & ~ output,
+      & ~ progress,
+      & ~ select,
+      & ~ textarea,
+      & ~ * button,
+      & ~ * input,
+      & ~ * meter,
+      & ~ * output,
+      & ~ * progress,
+      & ~ * select,
+      & ~ * textarea {
+        @include html-validator-warning('The <label> element may contain at most one <button>, <input>, <meter>, <output>, <progress>, <select>, or <textarea> descendant and/or no duplicated label values.');
+      }
+    }
+
+    div {
+      @include html-validator-warning('This element is allowed as child of element <label> in this context.');
+    }
+  }
+
+  picture {
+    &[width],
+    &[height] {
+      @include html-validator-warning('Attribute "width" not allowed on element picture at this point.');
+    }
+
+    :not(source) ~ img {
+      @include html-validator-warning('If element "img" is not used with "source", "width" and "height" should be applied.');
+    }
+  }
+
+  table {
+    > *:not(tr):not(thead):not(tbody):not(tfoot) {
+      @include html-validator-warning('This element is allowed as child of element <table> in this context.');
+    }
+  }
+
+  tr {
+    > *:not(td) {
+      @include html-validator-warning('This element is allowed as child of element <tr> in this context.');
+    }
+  }
+
+  span {
+    div {
+      @include html-validator-warning('Element <div> not allowed as child of element <span> in this context.');
+    }
+  }
+
+  ul {
+    > *:not(li) {
+      @include html-validator-warning('No element except <li> allowed as child of element <ul> in this context.');
+    }
+  }
+}

--- a/src/styleguide/html-validation.scss
+++ b/src/styleguide/html-validation.scss
@@ -71,7 +71,7 @@
     }
 
     div {
-      @include html-validator-warning('This element is allowed as child of element <label> in this context.');
+      @include html-validator-warning('This element is not allowed as child of element <label> in this context.');
     }
   }
 
@@ -88,13 +88,13 @@
 
   table {
     > *:not(tr):not(thead):not(tbody):not(tfoot) {
-      @include html-validator-warning('This element is allowed as child of element <table> in this context.');
+      @include html-validator-warning('This element is not allowed as child of element <table> in this context.');
     }
   }
 
   tr {
     > *:not(td) {
-      @include html-validator-warning('This element is allowed as child of element <tr> in this context.');
+      @include html-validator-warning('This element is not allowed as child of element <tr> in this context.');
     }
   }
 


### PR DESCRIPTION
## Pull request
Adds a basic setup for HTML validation with CSS. I decided not to use the tool from the ticket, but we might can copy the selectors from it one day.

Fixing the issues is an other story ;)
 
### Ticket
https://github.com/valantic/vue-template/issues/132
 
### Browser testing
- http://localhost:8080/styleguide/sandbox/forms
 
### Checklist
- [x] I merged the current development branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [x] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
