### PR TITLE
Creates property for overwrite the element for the e-button.

### DIFF
--- a/src/components/e-button.md
+++ b/src/components/e-button.md
@@ -135,3 +135,9 @@ Creates a button like link.
 ```vue
 <e-button @click="onStyleguideClick">A button<br />with wrapping<br />text</e-button>
 ```
+
+#### Custom element
+
+```vue
+<e-button element="span" @click="onStyleguideClick">Custom element button</e-button>
+```

--- a/src/components/e-button.md
+++ b/src/components/e-button.md
@@ -137,6 +137,8 @@ Creates a button like link.
 ```
 
 #### Custom element
+This option to overwrite the default "anchor" or "button" tag should get only used for edge cases where 
+a button has to be inside another anchor tag or similar.
 
 ```vue
 <e-button element="span" @click="onStyleguideClick">Custom element button</e-button>

--- a/src/components/e-button.vue
+++ b/src/components/e-button.vue
@@ -130,6 +130,8 @@
 
       /**
        * Overwrites the element of the button component.
+       * This option to overwrite the default "anchor" or "button" tag should get only used for edge cases where
+       * a button has to be inside another anchor tag or similar.
        */
       element: {
         type: String,

--- a/src/components/e-button.vue
+++ b/src/components/e-button.vue
@@ -127,6 +127,14 @@
         type: Boolean,
         default: false,
       },
+
+      /**
+       * Overwrites the element of the button component.
+       */
+      element: {
+        type: String,
+        default: null,
+      },
     },
 
     data() {
@@ -145,11 +153,6 @@
          * @type {Boolean} Internal flag to determine focus state.
          */
         hasFocus: this.focus,
-
-        /**
-         * Sets the element type for the component.
-         */
-        type: this.$attrs.href ? 'a' : 'button',
 
         /**
          * Determines if the current device uses touch.
@@ -201,7 +204,16 @@
         return this.progress && this.width !== 'full'
           ? this.getElementDimensions()
           : null;
-      }
+      },
+
+      /**
+       * Gets the type of the component (DOM element).
+       *
+       * @returns {String}
+       */
+      type() {
+        return this.element || (this.$attrs.href ? 'a' : 'button');
+      },
     },
     // watch: {},
 


### PR DESCRIPTION
## Pull request
* Adds the property `element` for to the e-button component which allows to overwrite the element.
 
### Ticket
#151 
 
### Browser testing
- http://localhost:6060/#!/Elements/e-button
 
### Checklist
- [x] I merged the current development branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [x] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [x] Did review code and documentation
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [x] Re-assign ticket to developer
