### PR TITLE
WIP: Rename/table row link

### DIFF
--- a/src/components/e-table.md
+++ b/src/components/e-table.md
@@ -224,3 +224,81 @@ Note: the 'no results' row can be customized with the 'noResults' slot.
     }
 </script>
 ```
+
+#### Row links
+
+```vue
+<template>
+  <div :class="b()">
+    <h1>Sandbox</h1>
+    <div>
+      <e-table :columns="columns" :items="items" :row-link="{ href: rowHref, title: 'The link title' }" />
+    </div>
+  </div>
+</template>
+
+<script>
+  import { commerce, name } from 'faker';
+  import dayjs from 'dayjs';
+  import ETable from '@/components/e-table';
+
+  export default {
+    name: 'sandbox',
+    components: { ETable },
+
+    data() {
+      return {
+        rowHref(item) {
+          return `#${item.id}`;
+        },
+        columns: [
+          {
+            title: 'Entry',
+            key: 'entry',
+            sortable: true,
+            slotName: 'entry',
+          },
+          {
+            title: 'Created by',
+            key: 'createdBy',
+            onClick(item, column) {
+              alert(`You clicked on "${item.createdBy}" in the column "${column.title}".`);
+            }
+          },
+          {
+            title: 'Last change',
+            key: 'lastChange',
+            sortable: true,
+            sort: (a, b) => (dayjs(a.lastChange).isBefore(dayjs(b.lastChange)) ? -1 : 1),
+            slotName: 'lastChange',
+            align: 'right',
+          },
+          {
+            title: 'Action',
+            slotName: 'rowAction',
+            align: 'right',
+          }
+        ]
+      };
+    },
+
+    computed: {
+      items() {
+        return Array(4).fill(null).map((item, index) => {
+          const createdBy = name.findName();
+          const entry = commerce.productName();
+
+          return {
+            id: index,
+            entry,
+            lastChange: dayjs().subtract(index, 'day'),
+            createdBy,
+            searchString: `${createdBy}`,
+            disabled: index === 3
+          };
+        });
+      },
+    },
+  };
+</script>
+```

--- a/src/components/e-table.vue
+++ b/src/components/e-table.vue
@@ -283,7 +283,7 @@
        * Enables the row link for a few ms to allow link specific context menus (even IE11).
        */
       enableRowLink() {
-        if (this.rowHref && !this.hasSelection) { // It was not possible to test for rowHref when binding the event.
+        if (this.rowHref && !this.hasSelection) { // It was not possible to test for rowHref when binding the event in the template.
           this.enableRowLinks = true;
 
           setTimeout(() => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -130,6 +130,7 @@ module.exports = (env, args = {}) => {
     new StyleLintPlugin({
       emitErrors: isProduction,
       emitWarning: !isProduction,
+      failOnError: isProduction,
       lintDirtyModulesOnly: !isProduction,
       context: 'src',
       files: [


### PR DESCRIPTION
## Pull request
This PR adds better support for row links:

- Allow right click on a row to get the link related context menu
- Allow ctrl/cmd click on row to open link in new tab
- Allow text selections inside the table without triggering redirect
 
### Ticket
No ticket
 
### Browser testing
- http://localhost:6060/#!/Elements/e-table/7
 
### Checklist
- [ ] I merged the current development branch (before testing)
- [ ] Added JSDoc and styleguide demo
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did run automated tests and linters
- [ ] Did assign ticket
- [ ] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
