### PR TITLE
Feature/#132 vue3 html validation component

### DIFF
--- a/src/styleguide/components/s-demo-settings.vue
+++ b/src/styleguide/components/s-demo-settings.vue
@@ -1,9 +1,7 @@
 <template>
   <ul :class="b()">
     <li :class="b('item')">
-      <s-toggle v-model="htmlValidation">
-        HTML validation
-      </s-toggle>
+      <s-html-validation />
       <s-toggle v-model="loggedIn">
         Logged in
       </s-toggle>
@@ -14,30 +12,24 @@
 <script lang="ts">
   import { defineComponent } from 'vue';
   import sToggle from './s-toggle.vue';
+  import sHtmlValidation from '@/styleguide/components/s-html-validation.vue';
 
   interface IData {
-    htmlValidation: boolean;
     loggedIn: boolean;
   }
-
-  const showHtmlValidationClass = 'html-validation';
 
   export default defineComponent({
     name: 's-demo-settings',
     status: 0, // TODO: remove when component was prepared for current project.
 
     components: {
+      sHtmlValidation,
       sToggle,
     },
 
     // props: {},
     data(): IData {
       return {
-        /**
-         * Determines if the HTML validation styles should be applied.
-         */
-        htmlValidation: true,
-
         /**
          * Determines if the user is logged in.
          */
@@ -46,18 +38,7 @@
     },
 
     // computed: {},
-    watch: {
-      htmlValidation: {
-        immediate: true,
-        handler(show) {
-          if (show) {
-            document.body.classList.add(showHtmlValidationClass);
-          } else {
-            document.body.classList.remove(showHtmlValidationClass);
-          }
-        }
-      },
-    },
+    // watch: {},
 
     // beforeCreate() {},
     // created() {},
@@ -86,5 +67,3 @@
     }
   }
 </style>
-
-<style src="@/styleguide/html-validation.scss"></style>

--- a/src/styleguide/components/s-html-validation.vue
+++ b/src/styleguide/components/s-html-validation.vue
@@ -1,0 +1,179 @@
+<template>
+  <s-toggle v-model="enabled">
+    HTML validation
+  </s-toggle>
+</template>
+
+<script lang="ts">
+  /* eslint-disable max-len -- required for <style> */
+  import { defineComponent } from 'vue';
+  import sToggle from './s-toggle.vue';
+
+  interface IData {
+
+    /**
+     * Determines if the HTML validation styles should be applied.
+     */
+    enabled: boolean
+  }
+
+  /**
+   * Adds a toggle to en-/disable CSS driven HTML validation.
+   */
+  export default defineComponent({
+    name: 's-html-validation',
+
+    components: {
+      sToggle,
+    },
+    // mixins: [],
+
+    // props: {},
+    data(): IData {
+      return {
+        enabled: true,
+      };
+    },
+
+    // computed: {},
+    watch: {
+      enabled: {
+        immediate: true,
+        handler(enabled: boolean) {
+          document.body.classList.toggle('s-html-validation--enabled', enabled);
+        },
+      },
+    },
+
+    // beforeCreate() {},
+    // created() {},
+    // beforeMount() {},
+    // mounted() {},
+    // beforeUpdate() {},
+    // updated() {},
+    // activated() {},
+    // deactivated() {},
+    // beforeDestroy() {},
+    // destroyed() {},
+
+    // methods: {},
+    // render() {},
+  });
+</script>
+
+<style lang="scss">
+  @use '../../setup/scss/variables';
+
+  // stylelint-disable max-line-length
+
+  .s-html-validation--enabled {
+    @mixin html-validator-warning($message: '') {
+      $red: #ff0000;
+      $black: #000000;
+
+      outline: 5px solid $red;
+
+      &::before {
+        content: $message;
+        position: absolute;
+        z-index: 1000;
+        border: 1px solid $red;
+        padding: 2px variables.$spacing--5;
+        background: lighten($red, 40%);
+        color: $black;
+        max-width: 200px;
+        font-size: 0.8rem;
+      }
+    }
+
+    a {
+      button {
+        @include html-validator-warning('The element <button> must not appear as a descendant of the <a> element.');
+      }
+    }
+
+    button {
+      &:not([aria-label]):not([aria-labelledby]):empty {
+        @include html-validator-warning('Ensure that <button> has meaningful content or is labelled appropriately.');
+      }
+
+      div {
+        @include html-validator-warning('Element <div> not allowed as child of element <button>.');
+      }
+    }
+
+    img {
+      &[sizes^=','] {
+        @include html-validator-warning('Bad value for attribute "sizes" on element <img>: Starts with empty source size.');
+      }
+    }
+
+    label {
+      button,
+      input,
+      meter,
+      output,
+      progress,
+      select,
+      textarea {
+        &[aria-label],
+        &:nth-of-type(2),
+        & ~ button,
+        & ~ input,
+        & ~ meter,
+        & ~ output,
+        & ~ progress,
+        & ~ select,
+        & ~ textarea,
+        & ~ * button,
+        & ~ * input,
+        & ~ * meter,
+        & ~ * output,
+        & ~ * progress,
+        & ~ * select,
+        & ~ * textarea {
+          @include html-validator-warning('The <label> element may contain at most one <button>, <input>, <meter>, <output>, <progress>, <select>, or <textarea> descendant and/or no duplicated label values.');
+        }
+      }
+
+      div {
+        @include html-validator-warning('This element is not allowed as child of element <label> in this context.');
+      }
+    }
+
+    picture {
+      &[width],
+      &[height] {
+        @include html-validator-warning('Attribute "width" not allowed on element picture at this point.');
+      }
+
+      :not(source) ~ img {
+        @include html-validator-warning('If element "img" is not used with "source", "width" and "height" should be applied.');
+      }
+    }
+
+    table {
+      > *:not(tr):not(thead):not(tbody):not(tfoot) {
+        @include html-validator-warning('This element is not allowed as child of element <table> in this context.');
+      }
+    }
+
+    tr {
+      > *:not(td, th) {
+        @include html-validator-warning('This element is not allowed as child of element <tr> in this context.');
+      }
+    }
+
+    span {
+      div {
+        @include html-validator-warning('Element <div> not allowed as child of element <span> in this context.');
+      }
+    }
+
+    ul {
+      > *:not(li) {
+        @include html-validator-warning('No element except <li> allowed as child of element <ul> in this context.');
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
## Pull request
This PR converts the styleguide setting `show HTML validations` to a separate component for easier sharing. Vue 3 version of  #244.
 
### Ticket
#132 
 
### Browser testing
- http://localhost:9090/styleguide/sandbox/forms
 
### Checklist
- [x] I merged the current development branch (before testing)
- [ ] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [x] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
