### PR TITLE
Make watch task run in development mode for better performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "npm run lint && npm run jest; exit 0;",
     "build": "NODE_ENV=production webpack --mode production",
     "build:profile": "NODE_ENV=production webpack --mode production --profile",
-    "build:watch": "NODE_ENV=production webpack --mode production --watch",
+    "build:watch": "NODE_ENV=production webpack --mode development --watch",
     "build:icons": "svg-sprite --config .svg-sprite.json src/assets/icons/*.svg",
     "lint-staged": "lint-staged",
     "prepare": "husky install",


### PR DESCRIPTION
## Pull request
This PR improves the performance of the `build:watch` task a lot, especially when it is triggered by a file change. The build output will of course a bit different, but that should not matter IMO, since this command should be used for local development only anyway.

I think most of the below checklist items do not apply to this PR, am I right?
 
### Checklist
- [x] I merged the current development branch (before testing)
- [ ] Added JSDoc and styleguide demo
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
