### PR TITLE
Feature/187_Provide_page_locale

### DIFF
--- a/src/setup/i18n.ts
+++ b/src/setup/i18n.ts
@@ -2,7 +2,7 @@ import { createI18n, IntlDateTimeFormat } from 'vue-i18n';
 import fallbackMessages from '../translations/de.json';
 import numberFormats from './localization.json';
 
-const pageLang = document?.documentElement?.lang;
+export const PAGE_LANG = document?.documentElement?.lang;
 
 export const I18N_FALLBACK = 'de';
 export const I18N_FALLBACK_MESSAGES = fallbackMessages;
@@ -35,7 +35,7 @@ const i18n = createI18n({
   fallbackLocale: I18N_FALLBACK,
   datetimeFormats: {
     [I18N_FALLBACK]: datetimeFormats,
-    [pageLang]: datetimeFormats,
+    [PAGE_LANG]: datetimeFormats,
   },
 
   warnHtmlInMessage: process.env.NODE_ENV !== 'production' ? 'error' : 'off',
@@ -92,6 +92,10 @@ export const i18nSetLocale = (locale: string): Promise<void> => { // eslint-disa
 
   if (i18n.global.locale !== locale) {
     return i18nLoadMessages(locale).then((newLocale) => {
+      import('../stores/plugins/api').then((module) => {
+        module.axiosInstance.defaults.headers.common.locale = newLocale;
+      });
+
       i18n.global.locale = newLocale;
     });
   }
@@ -99,4 +103,4 @@ export const i18nSetLocale = (locale: string): Promise<void> => { // eslint-disa
   return Promise.resolve();
 };
 
-i18nSetLocale(pageLang || I18N_FALLBACK);
+i18nSetLocale(PAGE_LANG || I18N_FALLBACK);

--- a/src/stores/plugins/api.ts
+++ b/src/stores/plugins/api.ts
@@ -46,34 +46,6 @@ declare module 'pinia' {
   }
 }
 
-// Enable tracking of requests in development environment.
-if (process.env.NODE_ENV !== 'production') {
-  const clone = require('@/helpers/clone.ts').default; // eslint-disable-line global-require, @typescript-eslint/no-var-requires
-  const exclude = [
-    /assets\//,
-  ];
-
-  axiosInstance.interceptors.request.use((config: AxiosRequestConfig) => {
-    if (!exclude.find(pattern => pattern.test(config.url || ''))) {
-      console.groupCollapsed(`=> ${config.method?.toUpperCase()} ${config.url}`); // eslint-disable-line no-console
-      console.dir(clone(config)); // eslint-disable-line no-console
-      console.groupEnd(); // eslint-disable-line no-console
-    }
-
-    return config;
-  });
-
-  axiosInstance.interceptors.response.use((response: AxiosResponse) => {
-    if (!exclude.find(pattern => pattern.test(response.config.url || ''))) {
-      console.groupCollapsed(`<= ${response.config.method?.toUpperCase()} ${response.config.url}`); // eslint-disable-line no-console
-      console.dir(clone(response)); // eslint-disable-line no-console
-      console.groupEnd(); // eslint-disable-line no-console
-    }
-
-    return response;
-  });
-}
-
 export default function api():IPluginApi {
   const notificationStoreInstance = notificationStore();
 

--- a/src/stores/plugins/api.ts
+++ b/src/stores/plugins/api.ts
@@ -1,5 +1,8 @@
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, {
+ AxiosError, AxiosRequestConfig, AxiosResponse, AxiosInstance,
+} from 'axios';
 import notificationStore, { INotificationItem } from '@/stores/notification';
+import { PAGE_LANG } from '@/setup/i18n';
 
 export interface IApi {
 
@@ -24,6 +27,15 @@ export interface IApi {
   delete: (url: string, config: AxiosRequestConfig) => Promise<AxiosResponse | AxiosError>;
 }
 
+// Creating an Axios instance to set general header properties (for each request)
+export const axiosInstance: AxiosInstance = axios.create({
+  headers: {
+    common: {
+      locale: PAGE_LANG,
+    },
+  },
+});
+
 interface IPluginApi {
   $api: IApi,
 }
@@ -41,7 +53,7 @@ if (process.env.NODE_ENV !== 'production') {
     /assets\//,
   ];
 
-  axios.interceptors.request.use((config: AxiosRequestConfig) => {
+  axiosInstance.interceptors.request.use((config: AxiosRequestConfig) => {
     if (!exclude.find(pattern => pattern.test(config.url || ''))) {
       console.groupCollapsed(`=> ${config.method?.toUpperCase()} ${config.url}`); // eslint-disable-line no-console
       console.dir(clone(config)); // eslint-disable-line no-console
@@ -51,7 +63,7 @@ if (process.env.NODE_ENV !== 'production') {
     return config;
   });
 
-  axios.interceptors.response.use((response: AxiosResponse) => {
+  axiosInstance.interceptors.response.use((response: AxiosResponse) => {
     if (!exclude.find(pattern => pattern.test(response.config.url || ''))) {
       console.groupCollapsed(`<= ${response.config.method?.toUpperCase()} ${response.config.url}`); // eslint-disable-line no-console
       console.dir(clone(response)); // eslint-disable-line no-console
@@ -107,28 +119,28 @@ export default function api():IPluginApi {
   return {
     $api: {
       get(url, config) {
-        return axios
+        return axiosInstance
           .get(url, config)
           .then(response => handleSuccess(response))
           .catch(error => handleError(error));
       },
 
       post(url, data, config) {
-        return axios
+        return axiosInstance
           .post(url, data, config)
           .then(response => handleSuccess(response))
           .catch(error => handleError(error));
       },
 
       patch(url, data, config) {
-        return axios
+        return axiosInstance
           .patch(url, data, config)
           .then(response => handleSuccess(response))
           .catch(error => handleError(error));
       },
 
       delete(url, config) {
-        return axios
+        return axiosInstance
           .delete(url, config)
           .then(response => handleSuccess(response))
           .catch(error => handleError(error));


### PR DESCRIPTION
## Pull request
Get current PAGE_LANG via dynamic import - add locale as default paramenter to the header of an axios instance - import AxiosInstance class from axios to use its defined interface

### Ticket
[187](https://github.com/valantic/vue-template/projects/1#card-87480323)
 
### Browser testing
http://localhost:9090/styleguide/sandbox/notifications
 
### Checklist
- [x] I merged the current development branch (before testing)
- [ ] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [ ] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
