### PR TITLE
Feature/185 Add no-image fallback for e-picture

### DIFF
--- a/src/elements/e-picture.vue
+++ b/src/elements/e-picture.vue
@@ -7,8 +7,8 @@
     >
     <img ref="image"
          :sizes="mappedSizes"
-         :src="internalSrcSet"
-         :internalSrcSet="fallback"
+         :srcset="internalSrcSet"
+         :src="fallback"
          :alt="alt"
          :loading="loading"
          :width="width || (ratio && ratio * fallbackHeight)"

--- a/src/elements/e-picture.vue
+++ b/src/elements/e-picture.vue
@@ -7,15 +7,15 @@
     >
     <img ref="image"
          :sizes="mappedSizes"
-         :srcset="src"
-         :src="fallback"
+         :src="internalSrcSet"
+         :internalSrcSet="fallback"
          :alt="alt"
          :loading="loading"
          :width="width || (ratio && ratio * fallbackHeight)"
          :height="height || (ratio && fallbackHeight)"
          :decoding="decoding"
          @load="onLoad"
-         @error="handleError"
+         @error="onError"
     >
   </picture>
 </template>
@@ -168,13 +168,12 @@
         /**
          * @type {String} Holds srcset string of comma separated sources with width value.
          */
-        src: this.srcset,
+        internalSrcSet: this.srcset,
 
         /**
          * @type {Number} Holds a fallback width in case only the ratio is defined.
          */
         fallbackHeight: 400,
-
       };
     },
 
@@ -282,8 +281,8 @@
       onLoad() {
         this.loaded = true;
       },
-      handleError() {
-        this.src = this.fallback;
+      onError() {
+        this.internalSrcSet = this.fallback;
       }
     },
     // render() {},

--- a/src/elements/e-picture.vue
+++ b/src/elements/e-picture.vue
@@ -219,9 +219,8 @@
         }
 
         const mappedSizesBreakpoints = {};
-        const fallback = sizes.fallback ? `,${sizes.fallback}px` : ',100vw';
-
-        return Object
+        const fallback = sizes.fallback ? `${sizes.fallback}px` : '100vw';
+        const mappedSizes = Object
           .keys(sizes)
           .map((breakpoint) => {
             if (breakpoint === 'fallback') {
@@ -242,8 +241,11 @@
             const viewWidth = Math.floor((mappedSizesBreakpoints[breakpoint] / breakpoint) * 100);
 
             return `(max-width: ${breakpoint}px) ${viewWidth}vw`;
-          })
-          .join(',') + fallback;
+          });
+
+        mappedSizes.push(fallback);
+
+        return mappedSizes.join(',');
       },
     },
 

--- a/src/elements/e-picture.vue
+++ b/src/elements/e-picture.vue
@@ -5,8 +5,9 @@
             :media="mediaQuery"
             :srcset="mediaSrcset"
     >
-    <img :sizes="mappedSizes"
-         :srcset="srcset"
+    <img ref="image"
+         :sizes="mappedSizes"
+         :srcset="src"
          :src="fallback"
          :alt="alt"
          :loading="loading"
@@ -14,6 +15,7 @@
          :height="height || (ratio && fallbackHeight)"
          :decoding="decoding"
          @load="onLoad"
+         @error="handleError"
     >
   </picture>
 </template>
@@ -65,7 +67,7 @@
        */
       fallback: {
         type: String,
-        required: true,
+        default: null,
       },
 
       /**
@@ -164,9 +166,15 @@
         loaded: false,
 
         /**
+         * @type {String} Holds srcset string of comma separated sources with width value.
+         */
+        src: this.srcset,
+
+        /**
          * @type {Number} Holds a fallback width in case only the ratio is defined.
          */
         fallbackHeight: 400,
+
       };
     },
 
@@ -238,8 +246,8 @@
           .join(',') + fallback;
       },
     },
-    // watch: {},
 
+    // watch: {},
     // beforeCreate() {},
     // created() {},
     // beforeMount() {},
@@ -272,6 +280,9 @@
       onLoad() {
         this.loaded = true;
       },
+      handleError() {
+        this.src = this.fallback;
+      }
     },
     // render() {},
   };
@@ -331,7 +342,7 @@
     }
 
     &--placeholder {
-      background-color: variables.$color-grayscale--500;
+      background-color: variables.$color-grayscale--200;
     }
   }
 </style>

--- a/src/setup/styleguide.routes.js
+++ b/src/setup/styleguide.routes.js
@@ -6,6 +6,7 @@ import forms from '@/styleguide/routes/forms';
 import notifications from '@/styleguide/routes/notifications';
 import tooltips from '@/styleguide/routes/tooltips';
 import map from '@/styleguide/routes/map';
+import picture from '@/styleguide/routes/picture';
 
 const root = '/styleguide';
 const categoryWrapper = {
@@ -87,6 +88,14 @@ export default [
         component: map,
         meta: {
           title: 'Google Map',
+        },
+      },
+      {
+        path: 'image',
+        name: 'Pictures',
+        component: picture,
+        meta: {
+          title: 'Pictures',
         },
       },
     ]

--- a/src/styleguide/routes/picture.vue
+++ b/src/styleguide/routes/picture.vue
@@ -1,0 +1,53 @@
+<template>
+  <l-default>
+    <e-picture alt="Altext"
+               width="300"
+               height="423"
+               :sizes="sizes"
+               srcset="https://images.pexels.com/photos/10313905/pexels-photo-10313905.jpeg"
+               fallback="https://images.pexels.com/photos/9074921/pexels-photo-9074921.jpeg"
+    />
+  </l-default>
+</template>
+
+<script>
+  import ePicture from '@/elements/e-picture.vue';
+  import LDefault from '../../layouts/l-default.vue';
+
+  export default {
+    name: 'pictures',
+    components: {
+      LDefault,
+      ePicture
+    },
+    // mixins: [],
+
+    // props: {},
+    data() {
+      return {
+        sizes: {
+          '(min-width: 1000px)': 1000,
+          '(min-width: 800px)': 800,
+          '(min-width: 600px)': 600,
+        },
+      };
+    },
+
+    // computed: {},
+    // watch: {},
+
+    // beforeCreate() {},
+    // created() {},
+    // beforeMount() {},
+    // mounted() {},
+    // beforeUpdate() {},
+    // updated() {},
+    // activated() {},
+    // deactivated() {},
+    // beforeDestroy() {},
+    // destroyed() {},
+
+    // methods: {},
+    // render() {},
+  };
+</script>

--- a/src/styleguide/routes/picture.vue
+++ b/src/styleguide/routes/picture.vue
@@ -1,23 +1,23 @@
 <template>
   <l-default>
-    <e-picture alt="Altext"
-               width="300"
-               height="423"
-               :sizes="sizes"
+    <e-picture :sizes="sizes"
                srcset="https://images.pexels.com/photos/10313905/pexels-photo-10313905.jpeg"
                fallback="https://images.pexels.com/photos/9074921/pexels-photo-9074921.jpeg"
+               width="300"
+               height="423"
+               alt="Image description"
     />
   </l-default>
 </template>
 
 <script>
   import ePicture from '@/elements/e-picture.vue';
-  import LDefault from '../../layouts/l-default.vue';
+  import lDefault from '../../layouts/l-default.vue';
 
   export default {
     name: 'pictures',
     components: {
-      LDefault,
+      lDefault,
       ePicture
     },
     // mixins: [],
@@ -26,9 +26,10 @@
     data() {
       return {
         sizes: {
-          '(min-width: 1000px)': 1000,
-          '(min-width: 800px)': 800,
-          '(min-width: 600px)': 600,
+          1440: 1400,
+          xs: 200,
+          sm: 400,
+          md: 800,
         },
       };
     },


### PR DESCRIPTION
## Pull request
Set the default value for the fallback property and make it optional - implement error handling for the img tag - store the srcset in data to be replaced with the fallback source in case the image resource specified in the srcset path is not found on the server - created picture route and page to test the component.
 
### Ticket
[185](https://github.com/valantic/vue-template/projects/1#card-87657797)
 
### Browser testing
http://localhost:9090/styleguide/sandbox/image
 
### Checklist
- [x] I merged the current development branch (before testing)
- [ ] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [ ] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
