### PR TITLE
BugFix/290 Corrects eProgress Position

### DIFF
--- a/src/components/e-progress.vue
+++ b/src/components/e-progress.vue
@@ -28,7 +28,7 @@
        */
       negative: {
         type: Boolean,
-        default: false
+        default: false,
       },
 
       /**
@@ -38,7 +38,7 @@
        */
       spacing: propScale(500, [
         0,
-        500
+        500,
       ]),
 
       /**
@@ -46,8 +46,8 @@
        */
       message: {
         type: String,
-        default: null // Translation can not be set here because it will not be computed
-      }
+        default: null, // Translation can not be set here because it will not be computed
+      },
     },
     // data() {
     //   return {};
@@ -111,32 +111,32 @@
   }
 
   .e-progress {
-    font-size: 1rem;
-    padding: $_e-progress--padding;
     display: flex;
     align-items: center;
+    padding: $_e-progress--padding;
+    font-size: 1rem;
 
     &--spacing-0 {
       padding: 0;
     }
 
     &__inner {
-      display: block;
       position: relative;
-      width: calc(1em * 4);
-      height: 1em;
+      display: block;
       float: left;
+      width: calc(1em * 4);
+      height: 1.1em;
     }
 
     &__bubble {
-      display: block;
-      height: 0.6em;
-      width: 0.6em;
-      left: 50%;
-      background-color: variables.$color-secondary--1;
       position: absolute;
+      left: 50%;
+      display: block;
+      width: 0.6em;
+      height: 0.6em;
       margin: variables.$spacing--5 auto 0;
       border-radius: 50%;
+      background-color: variables.$color-secondary--1;
       animation: e-progress-rotation-animation $_e-progress__animation-duration linear infinite;
 
       &:nth-child(1) {

--- a/src/components/e-select.vue
+++ b/src/components/e-select.vue
@@ -213,10 +213,7 @@
     // separator for state icons
     &__icon-wrapper {
       position: absolute;
-      top: 50%;
       right: variables.$spacing--5;
-      display: flex;
-      transform: translateY(-50%);
     }
 
     &__icon-splitter {
@@ -285,9 +282,7 @@
 
     &__progress-container {
       position: absolute;
-      top: 0;
-      left: 50%;
-      transform: translateX(-50%);
+      right: 0;
     }
   }
 </style>

--- a/src/components/e-select.vue
+++ b/src/components/e-select.vue
@@ -213,7 +213,9 @@
     // separator for state icons
     &__icon-wrapper {
       position: absolute;
+      top: 50%;
       right: variables.$spacing--5;
+      transform: translateY(-50%);
     }
 
     &__icon-splitter {
@@ -282,7 +284,9 @@
 
     &__progress-container {
       position: absolute;
-      right: 0;
+      top: 50%;
+      right: 30px;
+      transform: translateY(-50%);
     }
   }
 </style>


### PR DESCRIPTION
## Pull request
Relocates the eProgress loader to its correct position within the select field.
 
### Ticket
[290](https://github.com/valantic/vue-template/projects/1#card-87981117)
 
### Browser testing
http://localhost:9090/styleguide/sandbox/forms
 
### Checklist
- [x] I merged the current development branch (before testing)
- [] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [ ] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
