### PR TITLE
Bug fix/293 Add geocoder instance

### DIFF
--- a/src/components/c-google-maps.vue
+++ b/src/components/c-google-maps.vue
@@ -193,6 +193,8 @@
 
     beforeCreate() {
       loadMapsAPI(() => {
+        geocoder = new window.google.maps.Geocoder();
+
         this.$nextTick(() => {
           this.createMapInstance();
         });

--- a/src/setup/i18n.js
+++ b/src/setup/i18n.js
@@ -40,7 +40,7 @@ export const i18n = new VueI18n({
   warnHtmlInMessage: process.env.NODE_ENV !== 'production' ? 'error' : 'off',
   dateTimeFormats: {
     [I18N_FALLBACK]: dateTimeFormats,
-    [pageLang]: dateTimeFormats,
+    [PAGE_LANG]: dateTimeFormats,
   },
 
   /**


### PR DESCRIPTION
## Pull request
Creates a missing geocoder instance that allows to convert an address or place name into geographic coordinates (latitude and longitude) and vice versa - update pageLang variable to PAGE_LANG in i18n.js
 
### Ticket
[293](https://github.com/valantic/vue-template/projects/1#card-87982334)
 
### Browser testing
http://localhost:9090/styleguide/sandbox/map?theme=01
 
### Checklist
- [x] I merged the current development branch (before testing)
- [ ] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [ ] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
