### PR TITLE
Feature/185 Adds Fallback Function in e-picture component

### DIFF
--- a/src/components/e-picture.vue
+++ b/src/components/e-picture.vue
@@ -24,13 +24,13 @@
   import { BREAKPOINTS_MAX } from '@/setup/globals';
   import { IModifiers } from '@/plugins/vue-bem-cn/src/globals';
 
-  interface IImageSizes {
-    fallback: number;
-    lg: number,
-    md: number,
-    sm: number,
-    xs: number,
-    xxs: number,
+  export interface IImageSizes {
+    fallback?: number;
+    lg?: number;
+    md?: number;
+    sm?: number;
+    xs?: number;
+    xxs?: number;
     [key: number]: number;
   }
 
@@ -243,7 +243,7 @@
             // otherwise take the size key (which is a number in that case)
             const breakpointValue = BREAKPOINTS_MAX[breakpoint] || size as number;
 
-            mappedSizesPerBreakpoints[breakpointValue] = this.sizes[size as keyof IImageSizes];
+            mappedSizesPerBreakpoints[breakpointValue] = this.sizes[size as keyof IImageSizes] as number; // Todo: 'as number' is possible not the best way to tell TS, that the value will always exist.
 
             return breakpointValue;
           })

--- a/src/components/e-picture.vue
+++ b/src/components/e-picture.vue
@@ -290,14 +290,14 @@
       /**
        * Load event handler for the image element.
        */
-      onLoad() {
+      onLoad(): void {
         this.loaded = true;
       },
       
       /**
        * Load event handler when an error occurs with a image element.
        */
-      onError() {
+      onError(): void {
         this.internalSrcSet = this.fallback;
       },
     },

--- a/src/components/e-picture.vue
+++ b/src/components/e-picture.vue
@@ -6,7 +6,7 @@
             :srcset="mediaSrcset"
     >
     <img :sizes="mappedSizes"
-         :srcset="srcset"
+         :srcset="internalSrcSet"
          :src="fallback"
          :alt="alt"
          :loading="loading"
@@ -14,6 +14,7 @@
          :height="height || (ratio && fallbackHeight)"
          :decoding="decoding"
          @load="onLoad"
+         @error="onError"
     >
   </picture>
 </template>
@@ -40,6 +41,7 @@
   interface IData {
     loaded: boolean;
     fallbackHeight: number;
+    internalSrcSet: string;
   }
 
   /**
@@ -85,7 +87,7 @@
        */
       fallback: {
         type: String,
-        required: true,
+        default: null,
       },
 
       /**
@@ -183,6 +185,12 @@
          * Holds a fallback width in case only the ratio is defined.
          */
         fallbackHeight: 400,
+
+        /**
+         *  Holds srcset string of comma separated sources with width value.
+         */
+        internalSrcSet: this.srcset,
+
       };
     },
 
@@ -285,6 +293,13 @@
       onLoad() {
         this.loaded = true;
       },
+      
+      /**
+       * Load event handler when an error occurs with a image element.
+       */
+      onError() {
+        this.internalSrcSet = this.fallback;
+      },
     },
     // render() {},
   });
@@ -341,7 +356,7 @@
     }
 
     &--placeholder {
-      background-color: variables.$color-grayscale--500;
+      background-color: variables.$color-grayscale--200;
     }
   }
 </style>

--- a/src/setup/styleguide.routes.ts
+++ b/src/setup/styleguide.routes.ts
@@ -8,6 +8,7 @@ import forms from '@/styleguide/routes/r-forms.vue';
 import notifications from '@/styleguide/routes/r-notifications.vue';
 import wysiwyg from '@/styleguide/routes/r-wysiwyg.vue';
 import googleMaps from '@/styleguide/routes/r-google-maps.vue';
+import picture from '@/styleguide/routes/r-picture.vue';
 
 export interface IRoute {
   path: string;
@@ -99,6 +100,14 @@ export default [
         component: googleMaps,
         meta: {
           title: 'Google Maps',
+        },
+      },
+      {
+        path: 'image',
+        name: 'Pictures',
+        component: picture,
+        meta: {
+          title: 'Pictures',
         },
       },
     ],

--- a/src/styleguide/routes/r-picture.vue
+++ b/src/styleguide/routes/r-picture.vue
@@ -13,11 +13,11 @@
 <script lang="ts">
   import { defineComponent } from 'vue';
   import lDefault from '@/components/l-default.vue';
-  import ePicture from '@/components/e-picture.vue';
+  import ePicture, { IImageSizes } from '@/components/e-picture.vue';
 
   // interface ISetup {}
   interface IData {
-    sizes: { [key: number | string]: number};
+    sizes: IImageSizes;
   }
  
   /**

--- a/src/styleguide/routes/r-picture.vue
+++ b/src/styleguide/routes/r-picture.vue
@@ -1,0 +1,65 @@
+<template>
+  <l-default>
+    <e-picture :sizes="sizes"
+               srcset="https://images.pexels.com/photos/10313905/pexels-photo-10313905.jpeg"
+               fallback="https://images.pexels.com/photos/9074921/pexels-photo-9074921.jpeg"
+               width="300"
+               height="1500"
+               alt="Image description"
+    />
+  </l-default>
+</template>
+
+<script lang="ts">
+  import { defineComponent } from 'vue';
+  import lDefault from '@/components/l-default.vue';
+  import ePicture from '@/components/e-picture.vue';
+
+  // interface ISetup {}
+  interface IData {
+    sizes: { [key: number | string]: number};
+  }
+ 
+  /**
+   * A component that integrates the e-picture for testing its functionality and passing properties.
+   */
+  export default defineComponent({
+    name: 'r-pictures',
+    components: {
+      lDefault,
+      ePicture,
+    },
+
+    // props: {},
+    // emits: {},
+
+    // setup(): ISetup {},
+    data(): IData {
+      return {
+        sizes: {
+          1440: 1400,
+          xs: 200,
+          sm: 400,
+          md: 800,
+        },
+      };
+    },
+
+    // computed: {},
+    // watch: {},
+
+    // beforeCreate() {},
+    // created() {},
+    // beforeMount() {},
+    // mounted() {},
+    // beforeUpdate() {},
+    // updated() {},
+    // activated() {},
+    // deactivated() {},
+    // beforeUnmount() {},
+    // unmounted() {},
+
+    // methods: {},
+    // render() {},
+  });
+</script>


### PR DESCRIPTION
## Pull request
Migrates an existing e-picture component from vue2 into vue3 with all necessary imports and typescript declarations.

- Adds @error handler when an error occurs with a image element 
- declares interface IData with all data properties - sets default of fallback prop to "null" 
- creates new "picture" route in styleguide.routes.ts to test the e-picture.vue component 
- creates r-picture.vue to import e-picture component and pass props
 
### Ticket
[185](https://github.com/valantic/vue-template/projects/1#card-87657797)
 
### Browser testing
http://localhost:9090/styleguide/sandbox/image
 
### Checklist
- [x] I merged the current development branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [ ] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
