### PR TITLE
Feature/128 Updates v-outside-click directive

### DIFF
--- a/src/components/c-modal.vue
+++ b/src/components/c-modal.vue
@@ -7,7 +7,7 @@
             :class="b(modifiers)"
     >
       <div ref="container" :class="b('container')">
-        <div v-outside-click="{ handler: () => onOutsideClick(), }"
+        <div v-outside-click="onOutsideClick"
              ref="inner"
              :class="b('inner')"
         >

--- a/src/components/e-multiselect.vue
+++ b/src/components/e-multiselect.vue
@@ -43,7 +43,7 @@
     <!-- Content -->
     <transition name="top-slide">
       <span v-show="isOpen"
-            v-outside-click="{ exclude: ['fieldWrapper', 'searchField'], handler: close }"
+            v-outside-click="{ excludeRefs: ['fieldWrapper', 'searchField'], handler: close }"
             :class="b('options-wrapper')"
       >
         <ul :class="b('options-list')">

--- a/src/directives/outside-click.ts
+++ b/src/directives/outside-click.ts
@@ -1,4 +1,4 @@
-import { DirectiveBinding } from 'vue';
+import { DefineComponent, DirectiveBinding } from 'vue';
 
 const outsideClickEventConfig = { passive: true, capture: true };
 
@@ -25,13 +25,8 @@ interface IOutsideClickElement extends HTMLElement {
  * Directive to handle an outside click for a specific DOM element and/or given excludes.
  *
  * Examples:
- * <div v-oustide-click="handler"></div>
- * <div v-outside-click="{
- *   excludeRefs: [],
- *   excludeIds: [],
- *   excludeDOM: [],
- *   handler: () => {},
- * }"></div>
+ * <div v-oustide-click="TOutsideClickHandlerFunction"></div>
+ * <div v-outside-click="IOutsideClickValue"></div>
  */
 export default {
   name: 'outside-click',
@@ -74,7 +69,13 @@ export default {
             const excludedElement = binding.instance?.$refs[refName];
 
             if (Array.isArray(excludedElement)) {
-              return excludedElement.some(component => component.$el.contains(eventTarget));
+              return excludedElement.some((node: InstanceType<DefineComponent> | HTMLElement) => {
+                if (node instanceof HTMLElement) {
+                  return node.contains(eventTarget);
+                }
+
+                return node.$el.constructor(eventTarget);
+              });
             }
 
             if (excludedElement instanceof HTMLElement) {

--- a/src/directives/outside-click.ts
+++ b/src/directives/outside-click.ts
@@ -10,7 +10,7 @@ interface ICustomElement extends HTMLElement {
  * Directive to handle an outside click for a specific DOM element.
  *
  * Examples:
- *
+ * <div v-oustide-click="handler"></div>
  * <div v-outside-click="{
  *   exclude: [],
  *   excludeIds: [],
@@ -33,6 +33,12 @@ export default {
 
     // Click / Touchstart handler.
     el.outsideClickHandler = (event: Event) => {
+      const { handler, exclude = [], excludeIds = [] } = binding.value;
+      
+      if (!handler) {
+        throw new Error('No event handler defined for v-outside-click.');
+      }
+
       // These conditions are needed to detect scrolling on touch devices.
       if (event.type === 'scroll') {
         userIsScrolling = true;
@@ -45,8 +51,6 @@ export default {
 
         return;
       }
-
-      const { handler, exclude = [], excludeIds = [] } = binding.value;
 
       // We check to see if the clicked element is not the dialog element and not excluded.
       const eventTarget = event.target as Node;

--- a/src/directives/outside-click.ts
+++ b/src/directives/outside-click.ts
@@ -7,9 +7,9 @@ const storageKey = Symbol('Outside click directive instance');
 type TOutsideClickHandlerFunction = (event: Event) => void;
 
 interface IOutsideClickValue {
-  exclude: string[];
+  excludeRefs: string[];
   excludeIds: string[];
-  excludeDOM: HTMLElement[];
+  excludeElements: HTMLElement[];
   handler: TOutsideClickHandlerFunction;
 }
 
@@ -22,11 +22,12 @@ interface IOutsideClickElement extends HTMLElement {
 }
 
 /**
- * Directive to handle an outside click for a specific DOM element.
+ * Directive to handle an outside click for a specific DOM element and/or given excludes.
  *
  * Examples:
  * <div v-oustide-click="handler"></div>
  * <div v-outside-click="{
+ *   excludeRefs: [],
  *   excludeIds: [],
  *   excludeDOM: [],
  *   handler: () => {},
@@ -64,12 +65,12 @@ export default {
       if (el !== event.target && !el.contains(eventTarget) && handler) {
         if (typeof binding.value === 'object') {
           const {
-            exclude = [],
+            excludeRefs = [],
             excludeIds = [],
-            excludeDOM = [],
+            excludeElements = [],
           } = binding.value;
 
-          const clickedOnExcludedElement = !!exclude.find((refName) => {
+          const clickedOnExcludedElement = !!excludeRefs.find((refName) => {
             const excludedElement = binding.instance?.$refs[refName];
 
             if (Array.isArray(excludedElement)) {
@@ -88,7 +89,7 @@ export default {
 
             return element && element.contains(eventTarget);
           });
-          const clickOnExcludedDomElement = excludeDOM.some(element => element.contains(eventTarget));
+          const clickOnExcludedDomElement = excludeElements.some(element => element.contains(eventTarget));
 
           if (clickedOnExcludedElement || clickedOnExcludedId || clickOnExcludedDomElement) {
             return;

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -45,10 +45,6 @@ export default defineStore<typeof storeName, ISessionState, ISessionGetters, ISe
       googleMapsApiKey: null,
     };
 
-    if (process.env.NODE_ENV !== 'production') {
-      state.googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY as string;
-    }
-
     return state;
   },
   getters: {

--- a/src/styleguide/routes/r-forms.vue
+++ b/src/styleguide/routes/r-forms.vue
@@ -42,6 +42,7 @@
                            :options="mock.businessFields"
                            :state="v$.form.businessFields.$error ? 'error' : 'default'"
                            :notification="v$.form.businessFields.$error ? 'Required field' : ''"
+                           has-search
                            @blur="v$.form.businessFields.$touch()"
             />
           </e-label>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = (env, args = {}) => {
   const showProfile = args.profile || false;
   const globalVariables = {
     'process.env': {
-      ...process.env,
+      // ...process.env,
       'NODE_ENV': JSON.stringify(isProduction ? 'production' : 'development'), // Needed by vendor scripts
       'HAS_WATCHER': hasWatcher,
       'BUILD_TIMESTAMP': new Date().getTime(),


### PR DESCRIPTION
## Pull request
Allow a method as value instead of an object, because mostly no additional configuration is needed. 

- sets const handler definition on top of el.outsideClickHandler() 
- verify if the handler is valid 
- add example how to set handler on v-outside-click JSDocs

### Ticket
[128](https://github.com/valantic/vue-template/projects/1#card-87657929)
 
### Browser testing
http://localhost:9090/styleguide/sandbox/forms
Test on "e-mutli-select component"
 
### Checklist
- [x] I merged the current development branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [ ] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
