### PR TITLE
BugFix/290 Relocate eProgress without affecting Error Icons

### DIFF
--- a/src/elements/e-progress.vue
+++ b/src/elements/e-progress.vue
@@ -127,7 +127,7 @@
       display: block;
       position: relative;
       width: calc(1em * 4);
-      height: 1em;
+      height: 1.1em;
       float: left;
     }
 

--- a/src/elements/e-select.vue
+++ b/src/elements/e-select.vue
@@ -206,7 +206,9 @@
     // separator for state icons
     &__icon-wrapper {
       position: absolute;
+      top: 50%;
       right: variables.$spacing--5;
+      transform: translateY(-50%);
     }
 
     // separator for state icons
@@ -277,7 +279,9 @@
 
     &__progress-container {
       position: absolute;
-      right: 0;
+      top: 50%;
+      right: 30px;
+      transform: translateY(-50%);
     }
   }
 </style>


### PR DESCRIPTION
## Pull request
- adjusts position of .e-select__icon-wrapper with transform: translateY(-50%) 
- adjusts position of .e-select__progress-container with transform: translateY(-50%)
 
### Ticket
[290](https://github.com/valantic/vue-template/projects/1#card-87981117)
 
### Browser testing
http://localhost:9090/styleguide/sandbox/forms
 
### Checklist
- [x] I merged the current development branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [ ] Did run automated tests and linters
- [x] Did assign ticket
- x ] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
