### PR TITLE
#237 create video element for youtube and vimeo

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,7 +8,7 @@ module.exports = {
     {
       directory: '../src/stories/elements/',
       titlePrefix: 'Elements/',
-      files: '*.stories.js',
+      files: '*.stories.@(js|ts)',
     },
     {
       directory: '../src/stories/components/',

--- a/src/elements/e-video.vue
+++ b/src/elements/e-video.vue
@@ -4,7 +4,6 @@
       :class="b('iframe', { responsive: hasFixedSize() })"
       :src="mapSrc"
       :allowfullscreen="allowfullscreen"
-      :frameborder="frameborder"
       :width="width"
       :height="height"
     ></iframe>
@@ -64,18 +63,6 @@
       allowfullscreen: {
         type: Boolean,
         default: false,
-      },
-
-      /**
-       * Allows to add/remove the border around the player.
-       *
-       * When set to 0 the border is completely removed.
-       *
-       * Default from iframe is 2.
-       */
-      frameborder: {
-        type: String,
-        default: '2',
       },
 
       /**

--- a/src/elements/e-video.vue
+++ b/src/elements/e-video.vue
@@ -16,9 +16,9 @@
       :class="b('iframe')"
       :src="mapSrc"
       :allowfullscreen="allowfullscreen"
-      :frameborder="frameborder"
-      :width="width"
-      :height="height"
+      :frameborder="frameborder.toString()"
+      :width="width.toString()"
+      :height="height.toString()"
     ></iframe>
     <!-- </div> -->
   </div>
@@ -73,8 +73,8 @@
        * Default from iframe is 2
        */
       frameborder: {
-        type: String,
-        default: '2',
+        type: [String, Number],
+        default: 2,
       },
 
       /**

--- a/src/elements/e-video.vue
+++ b/src/elements/e-video.vue
@@ -218,13 +218,7 @@
        * Helper to check wether a string matches with entries in an array.
        */
       arrayHasString(arr: string[], searchString: string): boolean {
-        return arr.some((videoSource) => {
-          if (!searchString.startsWith(videoSource)) {
-            return false;
-          }
-
-          return true;
-        });
+        return arr.some(videoSource => searchString.startsWith(videoSource));
       },
     },
   // render() {},

--- a/src/elements/e-video.vue
+++ b/src/elements/e-video.vue
@@ -1,0 +1,201 @@
+<template>
+  <!-- CONFIG
+    baseUrl:
+      - vimeo: "https://player.vimeo.com/video/
+      - youtube: "https://www.youtube.com/embed/"
+    controls:
+      - youtube disables in src with ?controls=0
+      - vimeo not able to disable controls
+    size:
+      - width & height can either be responsive or hard coded
+      - youtube standard -> width="560", height="315" -->
+  <div :class="b()">
+    <!-- <div style="padding: 56.25% 0 0 0; position: relative"> -->
+    <!-- style="position: absolute; top: 0; left: 0; width: 100%; height: 100%" -->
+    <iframe
+      :class="b('iframe')"
+      :src="mapSrc"
+      :allowfullscreen="allowfullscreen"
+      :frameborder="frameborder"
+      :width="width"
+      :height="height"
+    ></iframe>
+    <!-- </div> -->
+  </div>
+</template>
+
+<script lang="ts">
+  import { PropType, defineComponent } from 'vue';
+
+  const videoUrlSources = {
+    youtube: 'https://www.youtube.com',
+    vimeo: 'https://vimeo.com/',
+  };
+
+  const playerUrlSources = {
+    youtube: 'https://www.youtube.com/embed/',
+    vimeo: 'https://player.vimeo.com/video/',
+  };
+
+  export default defineComponent({
+    name: 'e-video',
+    status: 0, // TODO: remove when component was prepared for current project.
+
+    // components: {},
+
+    props: {
+      /**
+       * Allows the user to watch the video in fullscreen
+       */
+      allowfullscreen: {
+        type: Boolean,
+        default: false,
+      },
+
+      /**
+       * Specifies the source of the video
+       *
+       * We can decide between youtube and vimeo
+       */
+      source: {
+        type: String as PropType<'youtube' | 'vimeo'>,
+        required: true,
+        validator(value: string) {
+          return Object.keys(playerUrlSources).includes(value);
+        },
+      },
+
+      /**
+       * Allows to add/remoe the border around the player
+       *
+       * When set to 0 the border is completely removed
+       *
+       * Default from iframe is 2
+       */
+      frameborder: {
+        type: String,
+        default: '2',
+      },
+
+      /**
+       * Accepts a valid url from a youtube or vimeo video
+       */
+      videoUrl: {
+        type: String,
+        default: null,
+      // validate against different sources
+      // validator: (value: string) => playerSources[this.source].includes(value)
+      // validator: (value: string) => {
+      //   return Object.values(videoUrlSources).includes(value);
+      // }
+      },
+
+      /**
+       * Accepts an ID from a youtube or vimeo video
+       */
+      videoId: {
+        type: String,
+        default: null,
+      },
+
+      /**
+       * Allows to set the video player width.
+       */
+      width: {
+        type: [String, Number],
+        default: 560,
+      },
+
+      /**
+       * Allows to set the video player height.
+       */
+      height: {
+        type: [String, Number],
+        default: 315,
+      },
+
+    /**
+     * Defines the players size to be responsive 100% width to the parent container
+     */
+    // responsive: {
+    //   type: Boolean,
+    //   default: null
+    // }
+    },
+
+    // emits: {},
+    // setup(): Setup {},
+
+    computed: {
+      mapSrc(): string | undefined {
+        const playerBaseUrl = playerUrlSources[this.source];
+
+        if (!(this.videoId || this.videoUrl)) {
+          // eslint-disable-next-line no-console
+          console.error("Neither 'videoId' or 'videoUrl' were defined", this.$el);
+
+          return undefined;
+        }
+
+        if (this.videoUrl && !this.videoId) {
+          if (this.source === 'youtube') {
+            /**
+             * Extract id from video url
+             */
+            const id = this.videoUrl.substring(
+              this.videoUrl.indexOf('v=') + 2,
+              this.videoUrl.indexOf('&')
+            );
+
+            return `${playerBaseUrl}${id}`;
+          }
+
+          const id = this.videoUrl.substring(
+            this.videoUrl.indexOf(videoUrlSources[this.source])
+              + videoUrlSources[this.source].length,
+            this.videoUrl.length
+          );
+
+          return `${playerBaseUrl}${id}`;
+        }
+
+        if (this.videoId.includes(videoUrlSources[this.source])) {
+          // eslint-disable-next-line no-console
+          console.error('video-id can not be part of a URL');
+
+          return undefined;
+        }
+
+        return `${playerBaseUrl}${this.videoId}`;
+      },
+    },
+
+  // computed: {},
+  // watch: {},
+
+  // beforeCreate() {},
+  // created() {},
+  // beforeMount() {},
+  // mounted() {},
+  // beforeUpdate() {},
+  // updated() {},
+  // activated() {},
+  // deactivated() {},
+  // beforeUnmount() {},
+  // unmounted() {},
+
+  // methods: {},
+  // render() {},v
+  });
+</script>
+
+<style lang="scss">
+@use '../setup/scss/variables';
+
+.e-video {
+  &__iframe {
+    display: flex;
+    margin: variables.$spacing--20 auto;
+  }
+}
+</style>

--- a/src/elements/e-video.vue
+++ b/src/elements/e-video.vue
@@ -1,30 +1,32 @@
 <template>
-  <!-- CONFIG
-    baseUrl:
-      - vimeo: "https://player.vimeo.com/video/
-      - youtube: "https://www.youtube.com/embed/"
-    controls:
-      - youtube disables in src with ?controls=0
-      - vimeo not able to disable controls
-    size:
-      - width & height can either be responsive or hard coded
-      - youtube standard -> width="560", height="315" -->
   <div :class="b()">
-    <!-- <div style="padding: 56.25% 0 0 0; position: relative"> -->
-    <!-- style="position: absolute; top: 0; left: 0; width: 100%; height: 100%" -->
-    <iframe
-      :class="b('iframe')"
-      :src="mapSrc"
-      :allowfullscreen="allowfullscreen"
-      :frameborder="frameborder.toString()"
-      :width="width.toString()"
-      :height="height.toString()"
-    ></iframe>
-    <!-- </div> -->
+    <div :class="responsive ? b('responsive') : null">
+      <iframe
+        :class="responsive ? b('iframe', { responsive }) : b('iframe')"
+        :src="mapSrc"
+        :allowfullscreen="allowfullscreen"
+        :frameborder="frameborder.toString()"
+        :width="width.toString()"
+        :height="height.toString()"
+      ></iframe>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
+
+/**
+ * CONFIG
+ *  baseUrl:
+ *    - vimeo: "https://player.vimeo.com/video/
+ *    - youtube: "https://www.youtube.com/embed/"
+ *  controls:
+ *    - youtube disables in src with ?controls=0
+ *    - vimeo not able to disable controls
+ *  size:
+ *    - width & height can either be responsive or hard coded
+ *    - youtube standard -> width="560", height="315"
+ */
   import { PropType, defineComponent } from 'vue';
 
   const videoUrlSources = {
@@ -83,11 +85,6 @@
       videoUrl: {
         type: String,
         default: null,
-      // validate against different sources
-      // validator: (value: string) => playerSources[this.source].includes(value)
-      // validator: (value: string) => {
-      //   return Object.values(videoUrlSources).includes(value);
-      // }
       },
 
       /**
@@ -114,13 +111,13 @@
         default: 315,
       },
 
-    /**
-     * Defines the players size to be responsive 100% width to the parent container
-     */
-    // responsive: {
-    //   type: Boolean,
-    //   default: null
-    // }
+      /**
+       * Defines the players size to be responsive 100% width to the parent container
+       */
+      responsive: {
+        type: Boolean,
+        default: false,
+      },
     },
 
     // emits: {},
@@ -138,6 +135,10 @@
         }
 
         if (this.videoUrl && !this.videoId) {
+          if (!this.validateUrl()) {
+            return undefined;
+          }
+
           if (this.source === 'youtube') {
             /**
              * Extract id from video url
@@ -170,22 +171,61 @@
       },
     },
 
-  // computed: {},
-  // watch: {},
+    // computed: {},
+    watch: {
+      /**
+       * This should check whether responsive or height + width are specified
+       */
+      $props: {
+        immediate: true,
+        handler() {
+          if (this.responsive && (this.width || this.height)) {
+            console.error('Either use responsive or height and width');
+          } else if (
+            (this.width && !this.height)
+            || (!this.width && this.height)
+          ) {
+            console.error('width and height both need to be specified');
+          }
+        },
+      },
+      videoUrl: {
+        immediate: true,
+        handler() {
+          this.validateUrl();
+        },
+      },
+    },
 
-  // beforeCreate() {},
-  // created() {},
-  // beforeMount() {},
-  // mounted() {},
-  // beforeUpdate() {},
-  // updated() {},
-  // activated() {},
-  // deactivated() {},
-  // beforeUnmount() {},
-  // unmounted() {},
+    // beforeCreate() {},
+    // created() {},
+    // beforeMount() {},
+    // mounted() {},
+    // beforeUpdate() {},
+    // updated() {},
+    // activated() {},
+    // deactivated() {},
+    // beforeUnmount() {},
+    // unmounted() {},
 
-  // methods: {},
-  // render() {},v
+    methods: {
+      /**
+       * This is a helper function to validate the videoUrl property
+       */
+      validateUrl(): boolean {
+        if (
+          this.videoUrl
+          && !this.videoUrl.includes(videoUrlSources[this.source])
+        ) {
+          console.error('Invalid video url');
+
+          return false;
+        }
+
+        return true;
+      },
+    },
+  // render() {},
   });
 </script>
 
@@ -193,9 +233,22 @@
 @use '../setup/scss/variables';
 
 .e-video {
+  &__responsive {
+    position: relative;
+    padding: 56.25% 0 0;
+  }
+
   &__iframe {
     display: flex;
     margin: variables.$spacing--20 auto;
+
+    &--responsive {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
   }
 }
 </style>

--- a/src/elements/e-video.vue
+++ b/src/elements/e-video.vue
@@ -3,7 +3,7 @@
     <iframe
       :class="b('iframe', { responsive: hasFixedSize() })"
       :src="mapSrc"
-      :allowfullscreen="allowfullscreen"
+      :allowfullscreen="allowFullscreen"
       :width="width"
       :height="height"
     ></iframe>
@@ -60,7 +60,7 @@
       /**
        * Allows the user to watch the video in fullscreen.
        */
-      allowfullscreen: {
+      allowFullscreen: {
         type: Boolean,
         default: false,
       },
@@ -124,11 +124,12 @@
           if (this.source === 'youtube') {
             /**
              * Extract id from youtube video url.
+             * This has to be done in 2 Steps:
+             * 1. extract search string from url
+             * 2. extract query parameter from search string
              */
-            console.log('map url', this.videoUrl);
-            const id = this.videoUrl.substring(
-              this.videoUrl.indexOf('v=') + 2,
-              this.videoUrl.indexOf('&')
+            const id = new URLSearchParams(new URL(this.videoUrl).search).get(
+              'v'
             );
 
             return `${playerBaseUrl}${id}`;
@@ -136,12 +137,9 @@
 
           /**
            * Extract id from vimeo video url.
+           * slice(1) to remove the leading /.
            */
-          const id = this.videoUrl.substring(
-            this.videoUrl.indexOf(VideoUrlSource[this.source])
-              + VideoUrlSource[this.source].length,
-            this.videoUrl.length
-          );
+          const id = new URL(this.videoUrl).pathname.slice(1);
 
           return `${playerBaseUrl}${id}`;
         }
@@ -164,9 +162,11 @@
        */
       $props: {
         immediate: true,
+        deep: true,
         handler() {
           if (this.width || this.height) {
             if (!this.height && !this.width) {
+              // eslint-disable-next-line no-console
               console.error('Both, width and height need to be specified');
             }
           }

--- a/src/elements/e-video.vue
+++ b/src/elements/e-video.vue
@@ -42,7 +42,6 @@
    */
   export default defineComponent({
     name: 'e-video',
-    status: 0, // TODO: remove when component was prepared for current project.
 
     // components: {},
 

--- a/src/elements/e-video.vue
+++ b/src/elements/e-video.vue
@@ -1,7 +1,7 @@
 <template>
-  <div :class="b({ responsive: hasFixedSize() })">
+  <div :class="b({ responsive: hasFixedSize })">
     <iframe
-      :class="b('iframe', { responsive: hasFixedSize() })"
+      :class="b('iframe', { responsive: hasFixedSize })"
       :src="mapSrc"
       :allowfullscreen="allowFullscreen"
       :width="width"
@@ -108,6 +108,37 @@
     // setup(): Setup {},
 
     computed: {
+      /**
+       * Returns a validity check for the video url.
+       */
+      validateUrl(): boolean {
+        if (this.videoUrl) {
+          /**
+           * This is for sources with multiple allowed urls.
+           * e.g. youtube (standard, short)
+           */
+          if (Array.isArray(VideoUrlSource[this.source])) {
+            const videoSources = VideoUrlSource[this.source] as string[];
+
+            return this.arrayHasString(videoSources, this.videoUrl);
+          }
+
+          if (!this.videoUrl.startsWith(VideoUrlSource[this.source] as string)) {
+            // eslint-disable-next-line no-console
+            console.error('Invalid video url', this.$el);
+
+            return false;
+          }
+
+          return true;
+        }
+
+        return true;
+      },
+
+      /**
+       * Returns the validated and adapted video source.
+       */
       mapSrc(): string | undefined {
         const playerBaseUrl = PlayerUrlSource[this.source];
 
@@ -119,7 +150,7 @@
         }
 
         if (this.videoUrl && !this.videoId) {
-          if (!this.validateUrl()) {
+          if (!this.validateUrl) {
             return undefined;
           }
 
@@ -142,7 +173,7 @@
         }
 
         /**
-         * The videoId can consist of lowercase/uppercase letters, numbers, dashes and underscore
+         * The videoId can consist of lowercase/uppercase letters, numbers, dashes and underscores.
          */
         if ((/[a-zA-Z0-9-_]/).test(this.videoId) === false) {
           // eslint-disable-next-line no-console
@@ -152,6 +183,13 @@
         }
 
         return this.replaceIdInUrl(playerBaseUrl, this.videoId);
+      },
+
+      /**
+       * Returns
+       */
+      hasFixedSize(): boolean {
+        return !this.width && !this.height;
       },
     },
 
@@ -178,42 +216,7 @@
 
     methods: {
       /**
-       * Helper function to validate the videoUrl property.
-       */
-      validateUrl(): boolean {
-        if (this.videoUrl) {
-          /**
-           * This is for sources with multiple urls.
-           * e.g. youtube
-           */
-          if (Array.isArray(VideoUrlSource[this.source])) {
-            const videoSources = VideoUrlSource[this.source] as string[];
-
-            return this.arrayHasString(videoSources, this.videoUrl);
-          }
-
-          if (!this.videoUrl.startsWith(VideoUrlSource[this.source] as string)) {
-            // eslint-disable-next-line no-console
-            console.error('Invalid video url', this.$el);
-
-            return false;
-          }
-
-          return true;
-        }
-
-        return true;
-      },
-
-      /**
-       * Helper function to determine if both, height and width are specified
-       */
-      hasFixedSize(): boolean {
-        return !this.width && !this.height;
-      },
-
-      /**
-       * This is a helper for replacing part of a string
+       * This is a helper for replacing part of a string.
        * @param original string
        * @param replace string | null
        */
@@ -229,7 +232,7 @@
       },
 
       /**
-       * Helper to check wether a string matches with entries in an array
+       * Helper to check wether a string matches with entries in an array.
        * @param arr string[]
        * @param searchString string
        */

--- a/src/setup/styleguide/routes.ts
+++ b/src/setup/styleguide/routes.ts
@@ -11,6 +11,7 @@ import table from '@/styleguide/routes/r-table.vue';
 import tooltips from '@/styleguide/routes/r-tooltips.vue';
 import googleMaps from '@/styleguide/routes/r-google-maps.vue';
 import picture from '@/styleguide/routes/r-picture.vue';
+import video from '@/styleguide/routes/r-video.vue';
 
 declare module 'vue-router' {
   interface RouteMeta {
@@ -20,7 +21,7 @@ declare module 'vue-router' {
     };
     query?: {
       [key: string]: string;
-    }
+    };
   }
 }
 
@@ -135,6 +136,14 @@ export default [
         component: picture,
         meta: {
           title: 'Pictures',
+        },
+      },
+      {
+        path: 'video',
+        name: 'Video',
+        component: video,
+        meta: {
+          title: 'Videos',
         },
       },
     ],

--- a/src/stories/elements/e-video.stories.ts
+++ b/src/stories/elements/e-video.stories.ts
@@ -1,0 +1,48 @@
+import { Meta, Story } from '@storybook/vue3';
+import eVideo from '@/elements/e-video.vue';
+
+export default {
+  component: eVideo,
+  argTypes: {
+    source: {
+      options: ['youtube', 'vimeo'],
+      control: 'select',
+    },
+    width: {
+      options: [null, '560'],
+      control: 'select',
+    },
+    height: {
+      options: [null, '315'],
+      control: 'select',
+    },
+  },
+  args: {
+    source: 'youtube',
+    allowFullscreen: false,
+    videoUrl: 'https://www.youtube.com/watch?v=rSSPwrdGx-M',
+    videoId: null,
+    width: null,
+    height: null,
+  },
+} as Meta;
+
+const Template: Story = args => ({
+  components: { eVideo },
+  setup() {
+    return { args };
+  },
+  template: '<e-video v-bind="args" />',
+});
+
+export const Youtube = Template.bind({});
+Youtube.args = {
+  source: 'youtube',
+  videoUrl: 'https://www.youtube.com/watch?v=rSSPwrdGx-M',
+};
+
+export const Vimeo = Template.bind({});
+Vimeo.args = {
+  source: 'vimeo',
+  videoId: '264037633',
+};

--- a/src/styleguide/routes/r-video.vue
+++ b/src/styleguide/routes/r-video.vue
@@ -6,7 +6,11 @@
       video-url="https://www.youtube.com/watch?v=WYs_Y4D3NUs&ab_channel=valantic"
     />
     <!-- youtube example with id -->
-    <e-video source="youtube" video-id="WYs_Y4D3NUs" responsive />
+    <e-video source="youtube"
+             video-id="WYs_Y4D3NUs"
+             width="560"
+             height="315"
+    />
 
     <!-- vimeo example with url -->
     <e-video source="vimeo" video-url="https://vimeo.com/264037633" />
@@ -60,11 +64,6 @@
 .r-video {
   &__form {
     display: flex;
-  }
-
-  .e-input {
-    flex-grow: 1;
-    margin-right: variables.$spacing--20;
   }
 }
 </style>

--- a/src/styleguide/routes/r-video.vue
+++ b/src/styleguide/routes/r-video.vue
@@ -4,6 +4,7 @@
     <e-video
       source="youtube"
       video-url="https://www.youtube.com/watch?v=WYs_Y4D3NUs&ab_channel=valantic"
+      allow-fullscreen
     />
     <!-- youtube example with id -->
     <e-video source="youtube"
@@ -16,7 +17,7 @@
     <e-video source="vimeo" video-url="https://vimeo.com/264037633" />
 
     <!-- vimeo example with id -->
-    <e-video source="vimeo" video-id="264037633" />
+    <e-video source="vimeo" video-id="264037633" allow-fullscreen />
   </div>
 </template>
 

--- a/src/styleguide/routes/r-video.vue
+++ b/src/styleguide/routes/r-video.vue
@@ -6,7 +6,7 @@
       video-url="https://www.youtube.com/watch?v=WYs_Y4D3NUs&ab_channel=valantic"
     />
     <!-- youtube example with id -->
-    <e-video source="youtube" video-id="WYs_Y4D3NUs" />
+    <e-video source="youtube" video-id="WYs_Y4D3NUs" responsive />
 
     <!-- vimeo example with url -->
     <e-video source="vimeo" video-url="https://vimeo.com/264037633" />
@@ -25,7 +25,7 @@
    * A component that integrates the e-picture for testing its functionality and passing properties.
    */
   export default defineComponent({
-    name: 'r-pictures',
+    name: 'r-videos',
 
     components: {
       eVideo,

--- a/src/styleguide/routes/r-video.vue
+++ b/src/styleguide/routes/r-video.vue
@@ -2,29 +2,36 @@
   <div :class="b()">
     <!-- youtube example with url -->
     <e-video
-      source="youtube"
+      :source="VideoSource.Youtube"
       video-url="https://www.youtube.com/watch?v=WYs_Y4D3NUs&ab_channel=valantic"
       allow-fullscreen
     />
     <!-- youtube example with id -->
-    <e-video source="youtube"
-             video-id="WYs_Y4D3NUs"
-             width="560"
-             height="315"
-    />
+    <e-video :source="VideoSource.Youtube" video-id="WYs_Y4D3NUs" />
 
     <!-- vimeo example with url -->
-    <e-video source="vimeo" video-url="https://vimeo.com/264037633" />
+    <e-video
+      :source="VideoSource.Vimeo"
+      video-url="https://vimeo.com/264037633"
+    />
 
     <!-- vimeo example with id -->
-    <e-video source="vimeo" video-id="264037633" allow-fullscreen />
+    <e-video
+      :source="VideoSource.Vimeo"
+      video-id="264037633"
+      allow-fullscreen
+    />
   </div>
 </template>
 
 <script lang="ts">
   import { defineComponent } from 'vue';
 
-  import eVideo from '@/elements/e-video.vue';
+  import eVideo, { VideoSource } from '@/elements/e-video.vue';
+
+  interface Setup {
+    VideoSource: typeof VideoSource;
+  }
 
   /**
    * A component that integrates the e-picture for testing its functionality and passing properties.
@@ -36,9 +43,13 @@
       eVideo,
     },
 
-  // props: {}, // emits: {},
+    // props: {}, // emits: {},
 
-  // setup(): Setup {},
+    setup(): Setup {
+      return {
+        VideoSource,
+      };
+    },
 
   // computed: {},
   // watch: {},

--- a/src/styleguide/routes/r-video.vue
+++ b/src/styleguide/routes/r-video.vue
@@ -1,0 +1,70 @@
+<template>
+  <div :class="b()">
+    <!-- youtube example with url -->
+    <e-video
+      source="youtube"
+      video-url="https://www.youtube.com/watch?v=WYs_Y4D3NUs&ab_channel=valantic"
+    />
+    <!-- youtube example with id -->
+    <e-video source="youtube" video-id="WYs_Y4D3NUs" />
+
+    <!-- vimeo example with url -->
+    <e-video source="vimeo" video-url="https://vimeo.com/264037633" />
+
+    <!-- vimeo example with id -->
+    <e-video source="vimeo" video-id="264037633" />
+  </div>
+</template>
+
+<script lang="ts">
+  import { defineComponent } from 'vue';
+
+  import eVideo from '@/elements/e-video.vue';
+
+  /**
+   * A component that integrates the e-picture for testing its functionality and passing properties.
+   */
+  export default defineComponent({
+    name: 'r-pictures',
+
+    components: {
+      eVideo,
+    },
+
+  // props: {}, // emits: {},
+
+  // setup(): Setup {},
+
+  // computed: {},
+  // watch: {},
+
+  // beforeCreate() {},
+  // created() {},
+  // beforeMount() {},
+  // mounted() {},
+  // beforeUpdate() {},
+  // updated() {},
+  // activated() {},
+  // deactivated() {},
+  // beforeUnmount() {},
+  // unmounted() {},
+
+  // methods: {},
+  // render() {},
+  });
+</script>
+
+<style lang="scss">
+@use '../../setup/scss/variables';
+
+.r-video {
+  &__form {
+    display: flex;
+  }
+
+  .e-input {
+    flex-grow: 1;
+    margin-right: variables.$spacing--20;
+  }
+}
+</style>


### PR DESCRIPTION
## Pull request
This PR introduces the new video element which can be used as following. 

For now it is **limited to youtube and vimeo**
It works with full video URL's or video ID's as seen in the examples below.

External control handling is not part of this PR.
 
Please notice, that there is no use of any Google/Vimeo SDK or API, it simply uses the embedded web players.

### Example with URL
```
<e-video
  source="youtube"
  video-url="https://www.youtube.com/watch?v=WYs_Y4D3NUs&ab_channel=valantic"
/>
```

### Example with ID
```
<e-video
  source="youtube"
  video-url="WYs_Y4D3NUs"
/>
```
#### Additional Properties
- `width: string | number`
- `height: string | number`
- `allowfullscreen: boolean`
- ~~`frameborder string | number `~~

### Ticket
#237 
 
### Browser testing
http://localhost:5173/styleguide/sandbox/video
 
### Checklist
- [ X ] I merged the current development branch (before testing)
- [ X ] Added JSDoc and styleguide demo
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did run automated tests and linters
- [ X ] Did assign ticket
- [ ] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
