### PR TITLE
Feature/#129 focus mask

### DIFF
--- a/src/plugins/v-focus/directives/focus-item.ts
+++ b/src/plugins/v-focus/directives/focus-item.ts
@@ -1,17 +1,22 @@
 import { DirectiveBinding } from 'vue';
 import state from '../state';
 
+// TODO: Hiding the mask causes instant background removal. I'm not sure, how this can be fixed...
+
 /**
  * Sets or removes a class depending on the current focus state.
  */
-function update(el: HTMLElement, binding: DirectiveBinding): void {
-  if (binding.value) {
+function updated(el: HTMLElement, binding: DirectiveBinding): void {
+  const enabled = !!binding.value;
+
+  if (enabled) {
     el.classList.add('focus-item');
   } else {
     el.classList.remove('focus-item');
   }
 
-  state.enabled = !!binding.value;
+  state.variant = binding.arg || undefined;
+  state.enabled = enabled;
 }
 
 /**
@@ -20,9 +25,16 @@ function update(el: HTMLElement, binding: DirectiveBinding): void {
 export default {
   name: 'focus-item',
 
-  beforeMount: update,
-  updated: update,
+  beforeMount(el: HTMLElement, binding: DirectiveBinding): void {
+    if (binding.value) {
+      updated(el, binding);
+    }
+  },
+
+  updated,
+
   unmounted(): void {
+    state.variant = undefined;
     state.enabled = false;
   },
 };

--- a/src/plugins/v-focus/directives/focus-item.ts
+++ b/src/plugins/v-focus/directives/focus-item.ts
@@ -1,19 +1,16 @@
 import { DirectiveBinding } from 'vue';
 import state from '../state';
 
-// TODO: Hiding the mask causes instant background removal. I'm not sure, how this can be fixed...
+const bemBlock = 'v-focus-item';
 
 /**
  * Sets or removes a class depending on the current focus state.
  */
 function updated(el: HTMLElement, binding: DirectiveBinding): void {
+  const focusModifier = `${bemBlock}--focus`;
   const enabled = !!binding.value;
 
-  if (enabled) {
-    el.classList.add('focus-item');
-  } else {
-    el.classList.remove('focus-item');
-  }
+  el.classList.toggle(focusModifier, enabled);
 
   state.variant = binding.arg || undefined;
   state.enabled = enabled;

--- a/src/plugins/v-focus/directives/focus-mask.ts
+++ b/src/plugins/v-focus/directives/focus-mask.ts
@@ -1,13 +1,36 @@
 import state from '../state';
 
+const bemBlock = 'focus-mask';
+
 /**
  * Adds or removes a focus class to the given element based on the current focus state.
  */
 function update(el: HTMLElement): void {
+  const visibleModifier = `${bemBlock}--visible`;
+  const variantModifier = state.variant && `${bemBlock}--variant-${state.variant}`;
+  const hidingModifier = `${bemBlock}--hiding`;
+
   if (state.enabled) { // This will also make the directive reactive to the observable.
-    el.classList.add('focus-mask');
+    el.classList.add(visibleModifier);
+
+    if (variantModifier) {
+      el.classList.add(variantModifier);
+    }
   } else {
-    el.classList.remove('focus-mask');
+    const removeClasses = (): void => {
+      el.classList.remove(visibleModifier);
+      el.classList.remove(hidingModifier);
+
+      if (variantModifier) {
+        el.classList.remove(variantModifier);
+      }
+
+      el.removeEventListener('transitionend', removeClasses);
+    };
+
+    el.addEventListener('transitionend', removeClasses);
+
+    el.classList.add(hidingModifier);
   }
 }
 
@@ -17,6 +40,13 @@ function update(el: HTMLElement): void {
 export default {
   name: 'focus-mask',
 
-  beforeMount: update,
+  mounted(el: HTMLElement): void {
+    el.classList.add(bemBlock);
+
+    if (state.enabled) {
+      update(el);
+    }
+  },
+
   updated: update,
 };

--- a/src/plugins/v-focus/directives/focus-mask.ts
+++ b/src/plugins/v-focus/directives/focus-mask.ts
@@ -1,6 +1,6 @@
 import state from '../state';
 
-const bemBlock = 'focus-mask';
+const bemBlock = 'v-focus-mask';
 
 /**
  * Adds or removes a focus class to the given element based on the current focus state.
@@ -18,8 +18,7 @@ function update(el: HTMLElement): void {
     }
   } else {
     const removeClasses = (): void => {
-      el.classList.remove(visibleModifier);
-      el.classList.remove(hidingModifier);
+      el.classList.remove(visibleModifier, hidingModifier);
 
       if (variantModifier) {
         el.classList.remove(variantModifier);

--- a/src/plugins/v-focus/directives/focus-mask.ts
+++ b/src/plugins/v-focus/directives/focus-mask.ts
@@ -5,7 +5,7 @@ const bemBlock = 'v-focus-mask';
 /**
  * Adds or removes a focus class to the given element based on the current focus state.
  */
-function update(el: HTMLElement): void {
+function updated(el: HTMLElement): void {
   const visibleModifier = `${bemBlock}--visible`;
   const variantModifier = state.variant && `${bemBlock}--variant-${state.variant}`;
   const hidingModifier = `${bemBlock}--hiding`;
@@ -43,9 +43,9 @@ export default {
     el.classList.add(bemBlock);
 
     if (state.enabled) {
-      update(el);
+      updated(el);
     }
   },
 
-  updated: update,
+  updated,
 };

--- a/src/plugins/v-focus/state.ts
+++ b/src/plugins/v-focus/state.ts
@@ -1,10 +1,20 @@
 import { reactive } from 'vue';
 
-export default reactive({
+type FocusState = {
+  enabled: boolean;
+  variant?: string;
+}
+
+const state: FocusState = reactive({
   /**
-    * @type {boolean} The current focus state (enabled/disabled).
-   *
-   * @public
-    */
+   * The current focus state (enabled/disabled).
+   */
   enabled: false,
+
+  /**
+   * Allows to use alternative mask variants.
+   */
+  variant: undefined,
 });
+
+export default state;

--- a/src/plugins/v-focus/styles/_focus-item.scss
+++ b/src/plugins/v-focus/styles/_focus-item.scss
@@ -1,9 +1,11 @@
 @use '../../../setup/scss/mixins';
 @use '../../../setup/scss/variables';
 
-.focus-item {
-  @include mixins.z-index(focusItem);
+.v-focus-item {
+  &--focus {
+    @include mixins.z-index(focusItem);
 
-  position: relative;
-  background-color: variables.$color-grayscale--1000;
+    position: relative;
+    background-color: variables.$color-grayscale--1000;
+  }
 }

--- a/src/plugins/v-focus/styles/_focus-item.scss
+++ b/src/plugins/v-focus/styles/_focus-item.scss
@@ -1,6 +1,9 @@
+@use '../../../setup/scss/mixins';
+@use '../../../setup/scss/variables';
+
 .focus-item {
-  @include z-index(focusItem);
+  @include mixins.z-index(focusItem);
 
   position: relative;
-  background-color: $color-grayscale--1000;
+  background-color: variables.$color-grayscale--1000;
 }

--- a/src/plugins/v-focus/styles/_focus-mask.scss
+++ b/src/plugins/v-focus/styles/_focus-mask.scss
@@ -18,7 +18,6 @@
 
     &::before {
       position: absolute;
-      display: block;
       width: auto;
       height: auto;
       opacity: 1;

--- a/src/plugins/v-focus/styles/_focus-mask.scss
+++ b/src/plugins/v-focus/styles/_focus-mask.scss
@@ -1,7 +1,7 @@
 @use '../../../setup/scss/variables';
 @use '../../../setup/scss/mixins';
 
-.focus-mask {
+.v-focus-mask {
   &::before {
     @include mixins.z-index(focusOverlay);
 

--- a/src/plugins/v-focus/styles/_focus-mask.scss
+++ b/src/plugins/v-focus/styles/_focus-mask.scss
@@ -1,16 +1,36 @@
+@use '../../../setup/scss/variables';
+@use '../../../setup/scss/mixins';
+
 .focus-mask {
-  position: relative;
-
   &::before {
-    @include z-index(focusOverlay);
+    @include mixins.z-index(focusOverlay);
 
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    display: block;
     content: '';
-    background: rgba($color-grayscale--600, 0.9);
+    width: 0;
+    height: 0;
+    opacity: 0;
+    background: variables.$color-grayscale--400;
+    transition: opacity variables.$transition-duration--200 ease-in-out;
+  }
+
+  &--visible {
+    position: relative;
+
+    &::before {
+      position: absolute;
+      display: block;
+      width: auto;
+      height: auto;
+      opacity: 1;
+      inset: 0;
+    }
+  }
+
+  &--hiding::before {
+    opacity: 0;
+  }
+
+  &--variant-color::before {
+    background: variables.$color-primary--1;
   }
 }

--- a/src/plugins/v-focus/styles/_focus-mask.scss
+++ b/src/plugins/v-focus/styles/_focus-mask.scss
@@ -9,7 +9,7 @@
     width: 0;
     height: 0;
     opacity: 0;
-    background: variables.$color-grayscale--400;
+    background: rgba(variables.$color-grayscale--400, 0.5);
     transition: opacity variables.$transition-duration--200 ease-in-out;
   }
 
@@ -31,6 +31,6 @@
   }
 
   &--variant-color::before {
-    background: variables.$color-primary--1;
+    background: rgba(variables.$color-primary--1, 0.5);
   }
 }

--- a/src/setup/plugins.ts
+++ b/src/setup/plugins.ts
@@ -7,7 +7,7 @@ import i18n from '@/setup/i18n'; // MUST come after i18n because of build order.
 import directives from '@/setup/directives';
 import components from '@/setup/ssr-components';
 import dayjs from '@/plugins/dayjs';
-// import VueFocus from '@/plugins/v-focus';
+import VueFocus from '@/plugins/v-focus';
 // import tooltip from '@/plugins/tooltip';
 
 export interface CustomPlugin {
@@ -28,6 +28,6 @@ export default [
   { plugin: directives },
   { plugin: components },
   // { plugin: tooltip},
-  // { plugin: VueFocus},
+  { plugin: VueFocus },
   { plugin: dayjs },
 ] satisfies CustomPlugin[];

--- a/src/setup/styleguide/routes.ts
+++ b/src/setup/styleguide/routes.ts
@@ -18,6 +18,9 @@ import picture from '@/styleguide/routes/components/r-picture.vue';
 import video from '@/styleguide/routes/components/r-video.vue';
 import consent from '@/styleguide/routes/components/r-consent.vue';
 
+// Directives
+import focusMask from '@/styleguide/routes/directives/r-focus-mask.vue';
+
 declare module 'vue-router' {
   interface RouteMeta {
     title: string;
@@ -179,6 +182,25 @@ export default [
         component: consent,
         meta: {
           title: 'Cookie consent',
+        },
+      },
+    ],
+  },
+  {
+    path: `${root}/directives`,
+    name: 'directivesWrapper',
+    redirect: `${root}/directives/index`,
+    component: categoryWrapper,
+    meta: {
+      title: 'Directives',
+    },
+    children: [
+      {
+        path: 'focus-mask',
+        name: 'Focus mask',
+        component: focusMask,
+        meta: {
+          title: 'Focus mask',
         },
       },
     ],

--- a/src/styleguide/routes/directives/r-focus-mask.vue
+++ b/src/styleguide/routes/directives/r-focus-mask.vue
@@ -12,17 +12,6 @@
         Toggle focus
       </button>
     </div>
-    <h2>Variant</h2>
-    <div v-focus-item:color="hasColorFocus">
-      I have the focus.
-      <br>
-      <br>
-      <button type="button"
-              @click="hasColorFocus = !hasColorFocus"
-      >
-        Toggle focus
-      </button>
-    </div>
   </div>
 </template>
 
@@ -33,7 +22,6 @@
 
   type Data = {
     hasFocus: boolean;
-    hasColorFocus: boolean;
   }
 
   /**
@@ -53,7 +41,6 @@
     data(): Data {
       return {
         hasFocus: false,
-        hasColorFocus: false,
       };
     },
 

--- a/src/styleguide/routes/directives/r-focus-mask.vue
+++ b/src/styleguide/routes/directives/r-focus-mask.vue
@@ -25,10 +25,10 @@
   }
 
   /**
-   * Showcase for the consent plugin.
+   * Showcase for the focus mask and item directives.
    */
   export default defineComponent({
-    name: 'r-consent',
+    name: 'r-focus-mask',
 
     // components: {},
 
@@ -64,9 +64,9 @@
 </script>
 
 <style lang="scss">
-  // @use '@/setup/scss/variables';
+  @use '@/setup/scss/variables';
 
-  .r-consent {
-    padding: 50px;
+  .r-focus-mask {
+    padding: variables.$spacing--50;
   }
 </style>

--- a/src/styleguide/routes/directives/r-focus-mask.vue
+++ b/src/styleguide/routes/directives/r-focus-mask.vue
@@ -1,0 +1,85 @@
+<template>
+  <div v-focus-mask :class="b()">
+    <h1>Focus mask</h1>
+    <h2>Default</h2>
+    <div v-focus-item="hasFocus">
+      I have the focus.
+      <br>
+      <br>
+      <button type="button"
+              @click="hasFocus = !hasFocus"
+      >
+        Toggle focus
+      </button>
+    </div>
+    <h2>Variant</h2>
+    <div v-focus-item:color="hasColorFocus">
+      I have the focus.
+      <br>
+      <br>
+      <button type="button"
+              @click="hasColorFocus = !hasColorFocus"
+      >
+        Toggle focus
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+  import { defineComponent } from 'vue';
+
+  // type Setup = {}
+
+  type Data = {
+    hasFocus: boolean;
+    hasColorFocus: boolean;
+  }
+
+  /**
+   * Showcase for the consent plugin.
+   */
+  export default defineComponent({
+    name: 'r-consent',
+
+    // components: {},
+
+    // props: {},
+    // emits: {},
+
+    // setup(): Setup {
+    //   return {};
+    // },
+    data(): Data {
+      return {
+        hasFocus: false,
+        hasColorFocus: false,
+      };
+    },
+
+    // computed: {},
+    // watch: {},
+
+    // beforeCreate() {},
+    // created() {},
+    // beforeMount() {},
+    // mounted() {},
+    // beforeUpdate() {},
+    // updated() {},
+    // activated() {},
+    // deactivated() {},
+    // beforeUnmount() {},
+    // unmounted() {},
+
+    // methods: {},
+    // render() {},
+  });
+</script>
+
+<style lang="scss">
+  // @use '@/setup/scss/variables';
+
+  .r-consent {
+    padding: 50px;
+  }
+</style>


### PR DESCRIPTION
## Pull request
This PR extends the focus-mask directive with the possibility to use alternative themes and adds a transition.

Unfortunately, the source already had the issue that, when the backdrop is fading out, the content already looses it's background. I was not sure how to fix this. So I created an additional bug ticket to not overboard here.
 
### Ticket
#129
 
### Browser testing
- http://localhost:5173/styleguide/directives/focus-mask
 
### Checklist
- [x] I merged the current development branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [x] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
