### PR TITLE
#342 e-multiselect invalid HTML

### DIFF
--- a/src/elements/e-multiselect.vue
+++ b/src/elements/e-multiselect.vue
@@ -302,7 +302,9 @@
     // beforeCreate() {},
     // created() {},
     // beforeMount() {},
-    // mounted() {},
+    mounted() {
+      window.addEventListener('click', this.onClick, { capture: true });
+    },
     // beforeUpdate() {},
     // updated() {},
     // activated() {},
@@ -311,6 +313,15 @@
     // destroyed() {},
 
     methods: {
+      /**
+       * Checks if the dropdown needs to be closed because of an outside click
+       */
+      onClick(event: MouseEvent) {
+        if (this.$el !== event.target && !this.$el.contains(event.target)) {
+          this.close();
+        }
+      },
+
       /**
        * Close options event handler.
        */

--- a/src/styleguide/routes/sandbox/r-forms.vue
+++ b/src/styleguide/routes/sandbox/r-forms.vue
@@ -54,7 +54,7 @@
                       @blur="v$.form.color.$touch()"
             />
           </e-label>
-          <e-label name="Business fields" required>
+          <e-label tag="span" name="Business fields" required>
             <e-multiselect v-model="form.businessFields"
                            :options="mock.businessFields"
                            :state="v$.form.businessFields.$error ? FieldState.Error : FieldState.Default"
@@ -378,7 +378,7 @@
       margin-bottom: variables.$spacing--50;
     }
 
-    .e-label:not(:last-of-type) {
+    .e-label:not(:last-child) {
       margin-bottom: variables.$spacing--20;
     }
 


### PR DESCRIPTION
## Pull request
This PR fixes an invalid HTML structure on the e-multiselect demo. Since multiple labels are present, I decided to hide the one for the main field and only keep the labels for the actual values.
 
### Ticket
https://github.com/valantic/vue-template/issues/342
 
### Browser testing
- http://localhost:5173/styleguide/sandbox/forms
 
### Checklist
- [x] I merged the current development branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [x] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
