### PR TITLE
#314 icon typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "npm run tsc && npm run lint && npm run test:unit -- --watch=false",
     "test:unit": "vitest --dir tests",
     "build": "vite build --mode=app",
-    "build:icons": "svg-sprite --config .svg-sprite.json src/assets/icons/*.svg",
+    "build:icons": "svg-sprite --config .svg-sprite.json src/assets/icons/*.svg; node ./update-ts-icon-type",
     "build:profile": "npm run build -- --mode=profile",
     "build:storybook": "storybook build --output-dir dist/storybook",
     "build:watch": "npm run build -- --watch",

--- a/src/compositions/form-states.ts
+++ b/src/compositions/form-states.ts
@@ -26,7 +26,7 @@ export type FormStates = {
   focus: Ref<boolean>;
   hover: Ref<boolean>;
   stateModifiers: ComputedRef<StateModifiers>;
-  stateIcon: ComputedRef<string>;
+  stateIcon: ComputedRef<Icon | null>;
   hasDefaultState: ComputedRef<boolean>;
 }
 
@@ -73,7 +73,7 @@ const formStates = (inputState: Ref<FieldState>): FormStates => {
   /**
    * Holds a string containing the icon name matching the current form element state.
    */
-  const stateIcon: ComputedRef<string> = computed(() => {
+  const stateIcon: ComputedRef<Icon | null> = computed(() => {
     switch (inputState.value) {
       case FieldState.Error:
         return 'i-error';
@@ -85,7 +85,7 @@ const formStates = (inputState: Ref<FieldState>): FormStates => {
         return 'i-info';
 
       default:
-        return '';
+        return null;
     }
   });
 

--- a/src/elements/e-icon.vue
+++ b/src/elements/e-icon.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent } from 'vue';
+  import { defineComponent, PropType } from 'vue';
   import spritePath from '@/assets/icons.svg';
 
   type SpecificIconSizes = {
@@ -53,7 +53,7 @@
        * Name of the svg icon
        */
       icon: {
-        type: String,
+        type: String as PropType<Icon>,
         required: true,
       },
 

--- a/src/elements/e-input.vue
+++ b/src/elements/e-input.vue
@@ -20,11 +20,12 @@
         <!-- @slot Use this slot for Content next to the input value. For e.g. icons or units. -->
         <slot></slot>
       </span>
-      <span v-if="!hasDefaultState && !focus" :class="b('icon-splitter')"></span>
-      <e-icon v-if="!hasDefaultState && !focus"
-              :class="b('state-icon')"
-              :icon="stateIcon"
-      />
+      <template v-if="!hasDefaultState && !focus && stateIcon">
+        <span :class="b('icon-splitter')"></span>
+        <e-icon :class="b('state-icon')"
+                :icon="stateIcon"
+        />
+      </template>
     </span>
     <span v-if="showNotification" :class="b('notification')">
       <c-form-notification :state="state">

--- a/src/elements/e-logo.vue
+++ b/src/elements/e-logo.vue
@@ -24,7 +24,7 @@
   import eIcon from '@/elements/e-icon.vue';
 
   type Logo = {
-    icon: string;
+    icon: Icon;
     alt: string;
     title: string;
   }
@@ -56,12 +56,12 @@
 
     computed: {
       /**
-       * Get's the correct logo depending on the theme value from the store.
+       * Gets the correct logo depending on the theme value from the store.
        */
       logo(): Logo {
         const title = this.$t('e-logo.linkTitle');
-        let icon = '';
         let alt = '';
+        let icon: Icon;
 
         switch (this.theme) {
           case '01':
@@ -70,23 +70,8 @@
             break;
 
           case '02':
-            icon = 'svg-logo-name-02';
+            icon = 'i-styleguide-heart';
             alt = 'example logo 02';
-            break;
-
-          case '03':
-            icon = 'svg-logo-name-03';
-            alt = 'example logo 03';
-            break;
-
-          case '04':
-            icon = 'svg-logo-name-04';
-            alt = 'example logo 04';
-            break;
-
-          case '05':
-            icon = 'svg-logo-name-05';
-            alt = 'example logo 05';
             break;
 
           default:

--- a/src/elements/e-multiselect.vue
+++ b/src/elements/e-multiselect.vue
@@ -30,7 +30,7 @@
               size="22"
               inline
       />
-      <e-icon v-else
+      <e-icon v-else-if="stateIcon"
               :class="b('state-icon')"
               :icon="stateIcon"
       />

--- a/src/elements/e-select.vue
+++ b/src/elements/e-select.vue
@@ -23,11 +23,12 @@
       </option>
     </select>
     <span :class="b('icon-wrapper')">
-      <span v-if="!hasDefaultState" :class="b('icon-splitter')"></span>
-      <e-icon v-if="!hasDefaultState && !focus"
-              :class="b('state-icon')"
-              :icon="stateIcon"
-      />
+      <template v-if="!hasDefaultState && !focus && stateIcon">
+        <span :class="b('icon-splitter')"></span>
+        <e-icon :class="b('state-icon')"
+                :icon="stateIcon"
+        />
+      </template>
       <span v-if="progress" :class="b('progress-container')">
         <e-progress />
       </span>

--- a/src/elements/e-textarea.vue
+++ b/src/elements/e-textarea.vue
@@ -10,7 +10,7 @@
               @input="onInput"
     >
     </textarea>
-    <span v-if="!hasDefaultState && !focus" :class="b('icon-wrapper')">
+    <span v-if="!hasDefaultState && !focus && stateIcon" :class="b('icon-wrapper')">
       <span :class="b('icon-splitter')"></span>
       <e-icon :class="b('state-icon')"
               :icon="stateIcon"

--- a/src/styleguide/components/s-icon-finder.vue
+++ b/src/styleguide/components/s-icon-finder.vue
@@ -76,7 +76,7 @@
   }
 
   type FilteredIcon = {
-    name: string;
+    name: Icon;
     negative: boolean;
   }
 
@@ -111,10 +111,6 @@
      * The sprite path to use.
      */
     spritePath: string;
-  }
-
-  type Icon = {
-    name: string;
   }
 
   const icons = import.meta.glob('@/assets/icons/*.svg');
@@ -157,21 +153,19 @@
        * Returns an array of query filtered icons.
        */
       filteredIcons(): FilteredIcon[] {
-        const list = this.icons.filter((icon: string) => icon.indexOf(this.filter) > -1);
-
-        return list.map((icon: string) => { // eslint-disable-line arrow-body-style
-          return {
+        return this.icons
+          .filter((icon): icon is Icon => icon.indexOf(this.filter) > -1)
+          .map((icon: Icon) => ({
             name: icon,
             negative: Boolean(icon.match(/negative/)),
-          };
-        });
+          }));
       },
     },
     methods: {
       /**
        * Event handler for copy to clipboard button.
        */
-      copyToClipboard(icon: Icon) {
+      copyToClipboard(icon: FilteredIcon) {
         const hiddenInput = this.input as HTMLInputElement;
         let template;
 

--- a/src/types/icon.d.ts
+++ b/src/types/icon.d.ts
@@ -1,0 +1,16 @@
+type Icon =
+  'i-arrow-2--left' |
+  'i-arrow-2--right' |
+  'i-arrow--down' |
+  'i-arrow--left' |
+  'i-arrow--right' |
+  'i-calendar' |
+  'i-check' |
+  'i-close' |
+  'i-error' |
+  'i-info' |
+  'i-play' |
+  'i-plus' |
+  'i-search' |
+  'i-styleguide-heart' |
+  'i-warning';

--- a/src/types/icon.d.ts
+++ b/src/types/icon.d.ts
@@ -1,9 +1,9 @@
-type Icon =
-  'i-arrow-2--left' |
-  'i-arrow-2--right' |
-  'i-arrow--down' |
+// Don't edit this file. Use the NPM script 'build:icons' instead.
+type Icon = 'i-arrow--down' |
   'i-arrow--left' |
   'i-arrow--right' |
+  'i-arrow-2--left' |
+  'i-arrow-2--right' |
   'i-calendar' |
   'i-check' |
   'i-close' |

--- a/update-ts-icon-type.js
+++ b/update-ts-icon-type.js
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+
+const iconFolder = 'src/assets/icons';
+const outputFile = 'src/types/icon.d.ts';
+
+fs.readdir(iconFolder, (error, files) => {
+  const iconList = `type Icon = ${files.map(file => `'${file.replace('.svg', '')}'`).join(' |\n  ')};\n`;
+
+  fs.writeFile(
+    outputFile,
+    `// Don't edit this file. Use the NPM script 'build:icons' instead.\n${iconList}`,
+    () => console.error
+  );
+});
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,6 +89,7 @@ export default defineConfig(({ command, mode }) => {
         assetsInlineLimit: 0, // TODO: check if it makes sense to increase this value.
         manifest: true,
         emptyOutDir: true,
+        sourcemap: true,
         copyPublicDir: true,
 
         // TODO: watch?


### PR DESCRIPTION
## Pull request
This PR adds icon name typing for `e-icon`. Please also check the updating of the type by running `npm run build:icons`.

Unknown icon names should be disallowed when using `e-icon`. Known icons should be listed as possible values (at least in PhpStorm).
 
### Ticket
https://github.com/valantic/vue-template/issues/314
 
### Browser testing
- http://localhost:5173/styleguide/sandbox/icons
 
### Checklist
- [x] I merged the current development branch (before testing)
- [x] Added JSDoc and styleguide demo
- [x] Tested all links in project relevant browsers
- [x] Tested all links in different screen sizes
- [x] Did run automated tests and linters
- [x] Did assign ticket
- [x] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer
